### PR TITLE
Keep GraphQL field names in API responses

### DIFF
--- a/archive/.gitattributes
+++ b/archive/.gitattributes
@@ -1,0 +1,1 @@
+problems.json linguist-generated

--- a/archive/problems.json
+++ b/archive/problems.json
@@ -1,4538 +1,4538 @@
 [
   {
-    "code": "two-sum",
-    "problemNumber": 1,
-    "name": "Two Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1,
+    "title": "Two Sum",
+    "titleSlug": "two-sum"
   },
   {
-    "code": "palindrome-number",
-    "problemNumber": 9,
-    "name": "Palindrome Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 9,
+    "title": "Palindrome Number",
+    "titleSlug": "palindrome-number"
   },
   {
-    "code": "roman-to-integer",
-    "problemNumber": 13,
-    "name": "Roman to Integer",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 13,
+    "title": "Roman to Integer",
+    "titleSlug": "roman-to-integer"
   },
   {
-    "code": "longest-common-prefix",
-    "problemNumber": 14,
-    "name": "Longest Common Prefix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 14,
+    "title": "Longest Common Prefix",
+    "titleSlug": "longest-common-prefix"
   },
   {
-    "code": "valid-parentheses",
-    "problemNumber": 20,
-    "name": "Valid Parentheses",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 20,
+    "title": "Valid Parentheses",
+    "titleSlug": "valid-parentheses"
   },
   {
-    "code": "merge-two-sorted-lists",
-    "problemNumber": 21,
-    "name": "Merge Two Sorted Lists",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 21,
+    "title": "Merge Two Sorted Lists",
+    "titleSlug": "merge-two-sorted-lists"
   },
   {
-    "code": "remove-duplicates-from-sorted-array",
-    "problemNumber": 26,
-    "name": "Remove Duplicates from Sorted Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 26,
+    "title": "Remove Duplicates from Sorted Array",
+    "titleSlug": "remove-duplicates-from-sorted-array"
   },
   {
-    "code": "remove-element",
-    "problemNumber": 27,
-    "name": "Remove Element",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 27,
+    "title": "Remove Element",
+    "titleSlug": "remove-element"
   },
   {
-    "code": "find-the-index-of-the-first-occurrence-in-a-string",
-    "problemNumber": 28,
-    "name": "Find the Index of the First Occurrence in a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 28,
+    "title": "Find the Index of the First Occurrence in a String",
+    "titleSlug": "find-the-index-of-the-first-occurrence-in-a-string"
   },
   {
-    "code": "search-insert-position",
-    "problemNumber": 35,
-    "name": "Search Insert Position",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 35,
+    "title": "Search Insert Position",
+    "titleSlug": "search-insert-position"
   },
   {
-    "code": "length-of-last-word",
-    "problemNumber": 58,
-    "name": "Length of Last Word",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 58,
+    "title": "Length of Last Word",
+    "titleSlug": "length-of-last-word"
   },
   {
-    "code": "plus-one",
-    "problemNumber": 66,
-    "name": "Plus One",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 66,
+    "title": "Plus One",
+    "titleSlug": "plus-one"
   },
   {
-    "code": "add-binary",
-    "problemNumber": 67,
-    "name": "Add Binary",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 67,
+    "title": "Add Binary",
+    "titleSlug": "add-binary"
   },
   {
-    "code": "sqrtx",
-    "problemNumber": 69,
-    "name": "Sqrt(x)",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 69,
+    "title": "Sqrt(x)",
+    "titleSlug": "sqrtx"
   },
   {
-    "code": "climbing-stairs",
-    "problemNumber": 70,
-    "name": "Climbing Stairs",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 70,
+    "title": "Climbing Stairs",
+    "titleSlug": "climbing-stairs"
   },
   {
-    "code": "remove-duplicates-from-sorted-list",
-    "problemNumber": 83,
-    "name": "Remove Duplicates from Sorted List",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 83,
+    "title": "Remove Duplicates from Sorted List",
+    "titleSlug": "remove-duplicates-from-sorted-list"
   },
   {
-    "code": "merge-sorted-array",
-    "problemNumber": 88,
-    "name": "Merge Sorted Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 88,
+    "title": "Merge Sorted Array",
+    "titleSlug": "merge-sorted-array"
   },
   {
-    "code": "binary-tree-inorder-traversal",
-    "problemNumber": 94,
-    "name": "Binary Tree Inorder Traversal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 94,
+    "title": "Binary Tree Inorder Traversal",
+    "titleSlug": "binary-tree-inorder-traversal"
   },
   {
-    "code": "same-tree",
-    "problemNumber": 100,
-    "name": "Same Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 100,
+    "title": "Same Tree",
+    "titleSlug": "same-tree"
   },
   {
-    "code": "symmetric-tree",
-    "problemNumber": 101,
-    "name": "Symmetric Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 101,
+    "title": "Symmetric Tree",
+    "titleSlug": "symmetric-tree"
   },
   {
-    "code": "maximum-depth-of-binary-tree",
-    "problemNumber": 104,
-    "name": "Maximum Depth of Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 104,
+    "title": "Maximum Depth of Binary Tree",
+    "titleSlug": "maximum-depth-of-binary-tree"
   },
   {
-    "code": "convert-sorted-array-to-binary-search-tree",
-    "problemNumber": 108,
-    "name": "Convert Sorted Array to Binary Search Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 108,
+    "title": "Convert Sorted Array to Binary Search Tree",
+    "titleSlug": "convert-sorted-array-to-binary-search-tree"
   },
   {
-    "code": "balanced-binary-tree",
-    "problemNumber": 110,
-    "name": "Balanced Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 110,
+    "title": "Balanced Binary Tree",
+    "titleSlug": "balanced-binary-tree"
   },
   {
-    "code": "minimum-depth-of-binary-tree",
-    "problemNumber": 111,
-    "name": "Minimum Depth of Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 111,
+    "title": "Minimum Depth of Binary Tree",
+    "titleSlug": "minimum-depth-of-binary-tree"
   },
   {
-    "code": "path-sum",
-    "problemNumber": 112,
-    "name": "Path Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 112,
+    "title": "Path Sum",
+    "titleSlug": "path-sum"
   },
   {
-    "code": "pascals-triangle",
-    "problemNumber": 118,
-    "name": "Pascal's Triangle",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 118,
+    "title": "Pascal's Triangle",
+    "titleSlug": "pascals-triangle"
   },
   {
-    "code": "pascals-triangle-ii",
-    "problemNumber": 119,
-    "name": "Pascal's Triangle II",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 119,
+    "title": "Pascal's Triangle II",
+    "titleSlug": "pascals-triangle-ii"
   },
   {
-    "code": "best-time-to-buy-and-sell-stock",
-    "problemNumber": 121,
-    "name": "Best Time to Buy and Sell Stock",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 121,
+    "title": "Best Time to Buy and Sell Stock",
+    "titleSlug": "best-time-to-buy-and-sell-stock"
   },
   {
-    "code": "valid-palindrome",
-    "problemNumber": 125,
-    "name": "Valid Palindrome",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 125,
+    "title": "Valid Palindrome",
+    "titleSlug": "valid-palindrome"
   },
   {
-    "code": "single-number",
-    "problemNumber": 136,
-    "name": "Single Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 136,
+    "title": "Single Number",
+    "titleSlug": "single-number"
   },
   {
-    "code": "linked-list-cycle",
-    "problemNumber": 141,
-    "name": "Linked List Cycle",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 141,
+    "title": "Linked List Cycle",
+    "titleSlug": "linked-list-cycle"
   },
   {
-    "code": "binary-tree-preorder-traversal",
-    "problemNumber": 144,
-    "name": "Binary Tree Preorder Traversal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 144,
+    "title": "Binary Tree Preorder Traversal",
+    "titleSlug": "binary-tree-preorder-traversal"
   },
   {
-    "code": "binary-tree-postorder-traversal",
-    "problemNumber": 145,
-    "name": "Binary Tree Postorder Traversal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 145,
+    "title": "Binary Tree Postorder Traversal",
+    "titleSlug": "binary-tree-postorder-traversal"
   },
   {
-    "code": "read-n-characters-given-read4",
-    "problemNumber": 157,
-    "name": "Read N Characters Given Read4",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 157,
+    "title": "Read N Characters Given Read4",
+    "titleSlug": "read-n-characters-given-read4"
   },
   {
-    "code": "intersection-of-two-linked-lists",
-    "problemNumber": 160,
-    "name": "Intersection of Two Linked Lists",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 160,
+    "title": "Intersection of Two Linked Lists",
+    "titleSlug": "intersection-of-two-linked-lists"
   },
   {
-    "code": "missing-ranges",
-    "problemNumber": 163,
-    "name": "Missing Ranges",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 163,
+    "title": "Missing Ranges",
+    "titleSlug": "missing-ranges"
   },
   {
-    "code": "excel-sheet-column-title",
-    "problemNumber": 168,
-    "name": "Excel Sheet Column Title",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 168,
+    "title": "Excel Sheet Column Title",
+    "titleSlug": "excel-sheet-column-title"
   },
   {
-    "code": "majority-element",
-    "problemNumber": 169,
-    "name": "Majority Element",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 169,
+    "title": "Majority Element",
+    "titleSlug": "majority-element"
   },
   {
-    "code": "two-sum-iii-data-structure-design",
-    "problemNumber": 170,
-    "name": "Two Sum III - Data structure design",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 170,
+    "title": "Two Sum III - Data structure design",
+    "titleSlug": "two-sum-iii-data-structure-design"
   },
   {
-    "code": "excel-sheet-column-number",
-    "problemNumber": 171,
-    "name": "Excel Sheet Column Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 171,
+    "title": "Excel Sheet Column Number",
+    "titleSlug": "excel-sheet-column-number"
   },
   {
-    "code": "reverse-bits",
-    "problemNumber": 190,
-    "name": "Reverse Bits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 190,
+    "title": "Reverse Bits",
+    "titleSlug": "reverse-bits"
   },
   {
-    "code": "number-of-1-bits",
-    "problemNumber": 191,
-    "name": "Number of 1 Bits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 191,
+    "title": "Number of 1 Bits",
+    "titleSlug": "number-of-1-bits"
   },
   {
-    "code": "happy-number",
-    "problemNumber": 202,
-    "name": "Happy Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 202,
+    "title": "Happy Number",
+    "titleSlug": "happy-number"
   },
   {
-    "code": "remove-linked-list-elements",
-    "problemNumber": 203,
-    "name": "Remove Linked List Elements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 203,
+    "title": "Remove Linked List Elements",
+    "titleSlug": "remove-linked-list-elements"
   },
   {
-    "code": "isomorphic-strings",
-    "problemNumber": 205,
-    "name": "Isomorphic Strings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 205,
+    "title": "Isomorphic Strings",
+    "titleSlug": "isomorphic-strings"
   },
   {
-    "code": "reverse-linked-list",
-    "problemNumber": 206,
-    "name": "Reverse Linked List",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 206,
+    "title": "Reverse Linked List",
+    "titleSlug": "reverse-linked-list"
   },
   {
-    "code": "contains-duplicate",
-    "problemNumber": 217,
-    "name": "Contains Duplicate",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 217,
+    "title": "Contains Duplicate",
+    "titleSlug": "contains-duplicate"
   },
   {
-    "code": "contains-duplicate-ii",
-    "problemNumber": 219,
-    "name": "Contains Duplicate II",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 219,
+    "title": "Contains Duplicate II",
+    "titleSlug": "contains-duplicate-ii"
   },
   {
-    "code": "count-complete-tree-nodes",
-    "problemNumber": 222,
-    "name": "Count Complete Tree Nodes",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 222,
+    "title": "Count Complete Tree Nodes",
+    "titleSlug": "count-complete-tree-nodes"
   },
   {
-    "code": "implement-stack-using-queues",
-    "problemNumber": 225,
-    "name": "Implement Stack using Queues",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 225,
+    "title": "Implement Stack using Queues",
+    "titleSlug": "implement-stack-using-queues"
   },
   {
-    "code": "invert-binary-tree",
-    "problemNumber": 226,
-    "name": "Invert Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 226,
+    "title": "Invert Binary Tree",
+    "titleSlug": "invert-binary-tree"
   },
   {
-    "code": "summary-ranges",
-    "problemNumber": 228,
-    "name": "Summary Ranges",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 228,
+    "title": "Summary Ranges",
+    "titleSlug": "summary-ranges"
   },
   {
-    "code": "power-of-two",
-    "problemNumber": 231,
-    "name": "Power of Two",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 231,
+    "title": "Power of Two",
+    "titleSlug": "power-of-two"
   },
   {
-    "code": "implement-queue-using-stacks",
-    "problemNumber": 232,
-    "name": "Implement Queue using Stacks",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 232,
+    "title": "Implement Queue using Stacks",
+    "titleSlug": "implement-queue-using-stacks"
   },
   {
-    "code": "palindrome-linked-list",
-    "problemNumber": 234,
-    "name": "Palindrome Linked List",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 234,
+    "title": "Palindrome Linked List",
+    "titleSlug": "palindrome-linked-list"
   },
   {
-    "code": "valid-anagram",
-    "problemNumber": 242,
-    "name": "Valid Anagram",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 242,
+    "title": "Valid Anagram",
+    "titleSlug": "valid-anagram"
   },
   {
-    "code": "shortest-word-distance",
-    "problemNumber": 243,
-    "name": "Shortest Word Distance",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 243,
+    "title": "Shortest Word Distance",
+    "titleSlug": "shortest-word-distance"
   },
   {
-    "code": "strobogrammatic-number",
-    "problemNumber": 246,
-    "name": "Strobogrammatic Number",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 246,
+    "title": "Strobogrammatic Number",
+    "titleSlug": "strobogrammatic-number"
   },
   {
-    "code": "meeting-rooms",
-    "problemNumber": 252,
-    "name": "Meeting Rooms",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 252,
+    "title": "Meeting Rooms",
+    "titleSlug": "meeting-rooms"
   },
   {
-    "code": "binary-tree-paths",
-    "problemNumber": 257,
-    "name": "Binary Tree Paths",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 257,
+    "title": "Binary Tree Paths",
+    "titleSlug": "binary-tree-paths"
   },
   {
-    "code": "add-digits",
-    "problemNumber": 258,
-    "name": "Add Digits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 258,
+    "title": "Add Digits",
+    "titleSlug": "add-digits"
   },
   {
-    "code": "ugly-number",
-    "problemNumber": 263,
-    "name": "Ugly Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 263,
+    "title": "Ugly Number",
+    "titleSlug": "ugly-number"
   },
   {
-    "code": "palindrome-permutation",
-    "problemNumber": 266,
-    "name": "Palindrome Permutation",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 266,
+    "title": "Palindrome Permutation",
+    "titleSlug": "palindrome-permutation"
   },
   {
-    "code": "missing-number",
-    "problemNumber": 268,
-    "name": "Missing Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 268,
+    "title": "Missing Number",
+    "titleSlug": "missing-number"
   },
   {
-    "code": "closest-binary-search-tree-value",
-    "problemNumber": 270,
-    "name": "Closest Binary Search Tree Value",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 270,
+    "title": "Closest Binary Search Tree Value",
+    "titleSlug": "closest-binary-search-tree-value"
   },
   {
-    "code": "first-bad-version",
-    "problemNumber": 278,
-    "name": "First Bad Version",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 278,
+    "title": "First Bad Version",
+    "titleSlug": "first-bad-version"
   },
   {
-    "code": "move-zeroes",
-    "problemNumber": 283,
-    "name": "Move Zeroes",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 283,
+    "title": "Move Zeroes",
+    "titleSlug": "move-zeroes"
   },
   {
-    "code": "word-pattern",
-    "problemNumber": 290,
-    "name": "Word Pattern",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 290,
+    "title": "Word Pattern",
+    "titleSlug": "word-pattern"
   },
   {
-    "code": "nim-game",
-    "problemNumber": 292,
-    "name": "Nim Game",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 292,
+    "title": "Nim Game",
+    "titleSlug": "nim-game"
   },
   {
-    "code": "flip-game",
-    "problemNumber": 293,
-    "name": "Flip Game",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 293,
+    "title": "Flip Game",
+    "titleSlug": "flip-game"
   },
   {
-    "code": "range-sum-query-immutable",
-    "problemNumber": 303,
-    "name": "Range Sum Query - Immutable",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 303,
+    "title": "Range Sum Query - Immutable",
+    "titleSlug": "range-sum-query-immutable"
   },
   {
-    "code": "power-of-three",
-    "problemNumber": 326,
-    "name": "Power of Three",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 326,
+    "title": "Power of Three",
+    "titleSlug": "power-of-three"
   },
   {
-    "code": "counting-bits",
-    "problemNumber": 338,
-    "name": "Counting Bits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 338,
+    "title": "Counting Bits",
+    "titleSlug": "counting-bits"
   },
   {
-    "code": "power-of-four",
-    "problemNumber": 342,
-    "name": "Power of Four",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 342,
+    "title": "Power of Four",
+    "titleSlug": "power-of-four"
   },
   {
-    "code": "reverse-string",
-    "problemNumber": 344,
-    "name": "Reverse String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 344,
+    "title": "Reverse String",
+    "titleSlug": "reverse-string"
   },
   {
-    "code": "reverse-vowels-of-a-string",
-    "problemNumber": 345,
-    "name": "Reverse Vowels of a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 345,
+    "title": "Reverse Vowels of a String",
+    "titleSlug": "reverse-vowels-of-a-string"
   },
   {
-    "code": "moving-average-from-data-stream",
-    "problemNumber": 346,
-    "name": "Moving Average from Data Stream",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 346,
+    "title": "Moving Average from Data Stream",
+    "titleSlug": "moving-average-from-data-stream"
   },
   {
-    "code": "intersection-of-two-arrays",
-    "problemNumber": 349,
-    "name": "Intersection of Two Arrays",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 349,
+    "title": "Intersection of Two Arrays",
+    "titleSlug": "intersection-of-two-arrays"
   },
   {
-    "code": "intersection-of-two-arrays-ii",
-    "problemNumber": 350,
-    "name": "Intersection of Two Arrays II",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 350,
+    "title": "Intersection of Two Arrays II",
+    "titleSlug": "intersection-of-two-arrays-ii"
   },
   {
-    "code": "logger-rate-limiter",
-    "problemNumber": 359,
-    "name": "Logger Rate Limiter",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 359,
+    "title": "Logger Rate Limiter",
+    "titleSlug": "logger-rate-limiter"
   },
   {
-    "code": "valid-perfect-square",
-    "problemNumber": 367,
-    "name": "Valid Perfect Square",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 367,
+    "title": "Valid Perfect Square",
+    "titleSlug": "valid-perfect-square"
   },
   {
-    "code": "guess-number-higher-or-lower",
-    "problemNumber": 374,
-    "name": "Guess Number Higher or Lower",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 374,
+    "title": "Guess Number Higher or Lower",
+    "titleSlug": "guess-number-higher-or-lower"
   },
   {
-    "code": "ransom-note",
-    "problemNumber": 383,
-    "name": "Ransom Note",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 383,
+    "title": "Ransom Note",
+    "titleSlug": "ransom-note"
   },
   {
-    "code": "first-unique-character-in-a-string",
-    "problemNumber": 387,
-    "name": "First Unique Character in a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 387,
+    "title": "First Unique Character in a String",
+    "titleSlug": "first-unique-character-in-a-string"
   },
   {
-    "code": "find-the-difference",
-    "problemNumber": 389,
-    "name": "Find the Difference",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 389,
+    "title": "Find the Difference",
+    "titleSlug": "find-the-difference"
   },
   {
-    "code": "is-subsequence",
-    "problemNumber": 392,
-    "name": "Is Subsequence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 392,
+    "title": "Is Subsequence",
+    "titleSlug": "is-subsequence"
   },
   {
-    "code": "binary-watch",
-    "problemNumber": 401,
-    "name": "Binary Watch",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 401,
+    "title": "Binary Watch",
+    "titleSlug": "binary-watch"
   },
   {
-    "code": "sum-of-left-leaves",
-    "problemNumber": 404,
-    "name": "Sum of Left Leaves",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 404,
+    "title": "Sum of Left Leaves",
+    "titleSlug": "sum-of-left-leaves"
   },
   {
-    "code": "convert-a-number-to-hexadecimal",
-    "problemNumber": 405,
-    "name": "Convert a Number to Hexadecimal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 405,
+    "title": "Convert a Number to Hexadecimal",
+    "titleSlug": "convert-a-number-to-hexadecimal"
   },
   {
-    "code": "valid-word-abbreviation",
-    "problemNumber": 408,
-    "name": "Valid Word Abbreviation",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 408,
+    "title": "Valid Word Abbreviation",
+    "titleSlug": "valid-word-abbreviation"
   },
   {
-    "code": "longest-palindrome",
-    "problemNumber": 409,
-    "name": "Longest Palindrome",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 409,
+    "title": "Longest Palindrome",
+    "titleSlug": "longest-palindrome"
   },
   {
-    "code": "fizz-buzz",
-    "problemNumber": 412,
-    "name": "Fizz Buzz",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 412,
+    "title": "Fizz Buzz",
+    "titleSlug": "fizz-buzz"
   },
   {
-    "code": "third-maximum-number",
-    "problemNumber": 414,
-    "name": "Third Maximum Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 414,
+    "title": "Third Maximum Number",
+    "titleSlug": "third-maximum-number"
   },
   {
-    "code": "add-strings",
-    "problemNumber": 415,
-    "name": "Add Strings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 415,
+    "title": "Add Strings",
+    "titleSlug": "add-strings"
   },
   {
-    "code": "valid-word-square",
-    "problemNumber": 422,
-    "name": "Valid Word Square",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 422,
+    "title": "Valid Word Square",
+    "titleSlug": "valid-word-square"
   },
   {
-    "code": "number-of-segments-in-a-string",
-    "problemNumber": 434,
-    "name": "Number of Segments in a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 434,
+    "title": "Number of Segments in a String",
+    "titleSlug": "number-of-segments-in-a-string"
   },
   {
-    "code": "arranging-coins",
-    "problemNumber": 441,
-    "name": "Arranging Coins",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 441,
+    "title": "Arranging Coins",
+    "titleSlug": "arranging-coins"
   },
   {
-    "code": "find-all-numbers-disappeared-in-an-array",
-    "problemNumber": 448,
-    "name": "Find All Numbers Disappeared in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 448,
+    "title": "Find All Numbers Disappeared in an Array",
+    "titleSlug": "find-all-numbers-disappeared-in-an-array"
   },
   {
-    "code": "assign-cookies",
-    "problemNumber": 455,
-    "name": "Assign Cookies",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 455,
+    "title": "Assign Cookies",
+    "titleSlug": "assign-cookies"
   },
   {
-    "code": "repeated-substring-pattern",
-    "problemNumber": 459,
-    "name": "Repeated Substring Pattern",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 459,
+    "title": "Repeated Substring Pattern",
+    "titleSlug": "repeated-substring-pattern"
   },
   {
-    "code": "hamming-distance",
-    "problemNumber": 461,
-    "name": "Hamming Distance",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 461,
+    "title": "Hamming Distance",
+    "titleSlug": "hamming-distance"
   },
   {
-    "code": "island-perimeter",
-    "problemNumber": 463,
-    "name": "Island Perimeter",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 463,
+    "title": "Island Perimeter",
+    "titleSlug": "island-perimeter"
   },
   {
-    "code": "number-complement",
-    "problemNumber": 476,
-    "name": "Number Complement",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 476,
+    "title": "Number Complement",
+    "titleSlug": "number-complement"
   },
   {
-    "code": "license-key-formatting",
-    "problemNumber": 482,
-    "name": "License Key Formatting",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 482,
+    "title": "License Key Formatting",
+    "titleSlug": "license-key-formatting"
   },
   {
-    "code": "max-consecutive-ones",
-    "problemNumber": 485,
-    "name": "Max Consecutive Ones",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 485,
+    "title": "Max Consecutive Ones",
+    "titleSlug": "max-consecutive-ones"
   },
   {
-    "code": "construct-the-rectangle",
-    "problemNumber": 492,
-    "name": "Construct the Rectangle",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 492,
+    "title": "Construct the Rectangle",
+    "titleSlug": "construct-the-rectangle"
   },
   {
-    "code": "teemo-attacking",
-    "problemNumber": 495,
-    "name": "Teemo Attacking",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 495,
+    "title": "Teemo Attacking",
+    "titleSlug": "teemo-attacking"
   },
   {
-    "code": "next-greater-element-i",
-    "problemNumber": 496,
-    "name": "Next Greater Element I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 496,
+    "title": "Next Greater Element I",
+    "titleSlug": "next-greater-element-i"
   },
   {
-    "code": "keyboard-row",
-    "problemNumber": 500,
-    "name": "Keyboard Row",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 500,
+    "title": "Keyboard Row",
+    "titleSlug": "keyboard-row"
   },
   {
-    "code": "find-mode-in-binary-search-tree",
-    "problemNumber": 501,
-    "name": "Find Mode in Binary Search Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 501,
+    "title": "Find Mode in Binary Search Tree",
+    "titleSlug": "find-mode-in-binary-search-tree"
   },
   {
-    "code": "base-7",
-    "problemNumber": 504,
-    "name": "Base 7",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 504,
+    "title": "Base 7",
+    "titleSlug": "base-7"
   },
   {
-    "code": "relative-ranks",
-    "problemNumber": 506,
-    "name": "Relative Ranks",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 506,
+    "title": "Relative Ranks",
+    "titleSlug": "relative-ranks"
   },
   {
-    "code": "perfect-number",
-    "problemNumber": 507,
-    "name": "Perfect Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 507,
+    "title": "Perfect Number",
+    "titleSlug": "perfect-number"
   },
   {
-    "code": "fibonacci-number",
-    "problemNumber": 509,
-    "name": "Fibonacci Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 509,
+    "title": "Fibonacci Number",
+    "titleSlug": "fibonacci-number"
   },
   {
-    "code": "detect-capital",
-    "problemNumber": 520,
-    "name": "Detect Capital",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 520,
+    "title": "Detect Capital",
+    "titleSlug": "detect-capital"
   },
   {
-    "code": "longest-uncommon-subsequence-i",
-    "problemNumber": 521,
-    "name": "Longest Uncommon Subsequence I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 521,
+    "title": "Longest Uncommon Subsequence I",
+    "titleSlug": "longest-uncommon-subsequence-i"
   },
   {
-    "code": "minimum-absolute-difference-in-bst",
-    "problemNumber": 530,
-    "name": "Minimum Absolute Difference in BST",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 530,
+    "title": "Minimum Absolute Difference in BST",
+    "titleSlug": "minimum-absolute-difference-in-bst"
   },
   {
-    "code": "reverse-string-ii",
-    "problemNumber": 541,
-    "name": "Reverse String II",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 541,
+    "title": "Reverse String II",
+    "titleSlug": "reverse-string-ii"
   },
   {
-    "code": "diameter-of-binary-tree",
-    "problemNumber": 543,
-    "name": "Diameter of Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 543,
+    "title": "Diameter of Binary Tree",
+    "titleSlug": "diameter-of-binary-tree"
   },
   {
-    "code": "student-attendance-record-i",
-    "problemNumber": 551,
-    "name": "Student Attendance Record I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 551,
+    "title": "Student Attendance Record I",
+    "titleSlug": "student-attendance-record-i"
   },
   {
-    "code": "reverse-words-in-a-string-iii",
-    "problemNumber": 557,
-    "name": "Reverse Words in a String III",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 557,
+    "title": "Reverse Words in a String III",
+    "titleSlug": "reverse-words-in-a-string-iii"
   },
   {
-    "code": "maximum-depth-of-n-ary-tree",
-    "problemNumber": 559,
-    "name": "Maximum Depth of N-ary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 559,
+    "title": "Maximum Depth of N-ary Tree",
+    "titleSlug": "maximum-depth-of-n-ary-tree"
   },
   {
-    "code": "array-partition",
-    "problemNumber": 561,
-    "name": "Array Partition",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 561,
+    "title": "Array Partition",
+    "titleSlug": "array-partition"
   },
   {
-    "code": "binary-tree-tilt",
-    "problemNumber": 563,
-    "name": "Binary Tree Tilt",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 563,
+    "title": "Binary Tree Tilt",
+    "titleSlug": "binary-tree-tilt"
   },
   {
-    "code": "reshape-the-matrix",
-    "problemNumber": 566,
-    "name": "Reshape the Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 566,
+    "title": "Reshape the Matrix",
+    "titleSlug": "reshape-the-matrix"
   },
   {
-    "code": "subtree-of-another-tree",
-    "problemNumber": 572,
-    "name": "Subtree of Another Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 572,
+    "title": "Subtree of Another Tree",
+    "titleSlug": "subtree-of-another-tree"
   },
   {
-    "code": "distribute-candies",
-    "problemNumber": 575,
-    "name": "Distribute Candies",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 575,
+    "title": "Distribute Candies",
+    "titleSlug": "distribute-candies"
   },
   {
-    "code": "n-ary-tree-preorder-traversal",
-    "problemNumber": 589,
-    "name": "N-ary Tree Preorder Traversal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 589,
+    "title": "N-ary Tree Preorder Traversal",
+    "titleSlug": "n-ary-tree-preorder-traversal"
   },
   {
-    "code": "n-ary-tree-postorder-traversal",
-    "problemNumber": 590,
-    "name": "N-ary Tree Postorder Traversal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 590,
+    "title": "N-ary Tree Postorder Traversal",
+    "titleSlug": "n-ary-tree-postorder-traversal"
   },
   {
-    "code": "longest-harmonious-subsequence",
-    "problemNumber": 594,
-    "name": "Longest Harmonious Subsequence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 594,
+    "title": "Longest Harmonious Subsequence",
+    "titleSlug": "longest-harmonious-subsequence"
   },
   {
-    "code": "range-addition-ii",
-    "problemNumber": 598,
-    "name": "Range Addition II",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 598,
+    "title": "Range Addition II",
+    "titleSlug": "range-addition-ii"
   },
   {
-    "code": "minimum-index-sum-of-two-lists",
-    "problemNumber": 599,
-    "name": "Minimum Index Sum of Two Lists",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 599,
+    "title": "Minimum Index Sum of Two Lists",
+    "titleSlug": "minimum-index-sum-of-two-lists"
   },
   {
-    "code": "design-compressed-string-iterator",
-    "problemNumber": 604,
-    "name": "Design Compressed String Iterator",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 604,
+    "title": "Design Compressed String Iterator",
+    "titleSlug": "design-compressed-string-iterator"
   },
   {
-    "code": "can-place-flowers",
-    "problemNumber": 605,
-    "name": "Can Place Flowers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 605,
+    "title": "Can Place Flowers",
+    "titleSlug": "can-place-flowers"
   },
   {
-    "code": "merge-two-binary-trees",
-    "problemNumber": 617,
-    "name": "Merge Two Binary Trees",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 617,
+    "title": "Merge Two Binary Trees",
+    "titleSlug": "merge-two-binary-trees"
   },
   {
-    "code": "maximum-product-of-three-numbers",
-    "problemNumber": 628,
-    "name": "Maximum Product of Three Numbers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 628,
+    "title": "Maximum Product of Three Numbers",
+    "titleSlug": "maximum-product-of-three-numbers"
   },
   {
-    "code": "average-of-levels-in-binary-tree",
-    "problemNumber": 637,
-    "name": "Average of Levels in Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 637,
+    "title": "Average of Levels in Binary Tree",
+    "titleSlug": "average-of-levels-in-binary-tree"
   },
   {
-    "code": "maximum-average-subarray-i",
-    "problemNumber": 643,
-    "name": "Maximum Average Subarray I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 643,
+    "title": "Maximum Average Subarray I",
+    "titleSlug": "maximum-average-subarray-i"
   },
   {
-    "code": "set-mismatch",
-    "problemNumber": 645,
-    "name": "Set Mismatch",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 645,
+    "title": "Set Mismatch",
+    "titleSlug": "set-mismatch"
   },
   {
-    "code": "two-sum-iv-input-is-a-bst",
-    "problemNumber": 653,
-    "name": "Two Sum IV - Input is a BST",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 653,
+    "title": "Two Sum IV - Input is a BST",
+    "titleSlug": "two-sum-iv-input-is-a-bst"
   },
   {
-    "code": "robot-return-to-origin",
-    "problemNumber": 657,
-    "name": "Robot Return to Origin",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 657,
+    "title": "Robot Return to Origin",
+    "titleSlug": "robot-return-to-origin"
   },
   {
-    "code": "image-smoother",
-    "problemNumber": 661,
-    "name": "Image Smoother",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 661,
+    "title": "Image Smoother",
+    "titleSlug": "image-smoother"
   },
   {
-    "code": "second-minimum-node-in-a-binary-tree",
-    "problemNumber": 671,
-    "name": "Second Minimum Node In a Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 671,
+    "title": "Second Minimum Node In a Binary Tree",
+    "titleSlug": "second-minimum-node-in-a-binary-tree"
   },
   {
-    "code": "longest-continuous-increasing-subsequence",
-    "problemNumber": 674,
-    "name": "Longest Continuous Increasing Subsequence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 674,
+    "title": "Longest Continuous Increasing Subsequence",
+    "titleSlug": "longest-continuous-increasing-subsequence"
   },
   {
-    "code": "valid-palindrome-ii",
-    "problemNumber": 680,
-    "name": "Valid Palindrome II",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 680,
+    "title": "Valid Palindrome II",
+    "titleSlug": "valid-palindrome-ii"
   },
   {
-    "code": "baseball-game",
-    "problemNumber": 682,
-    "name": "Baseball Game",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 682,
+    "title": "Baseball Game",
+    "titleSlug": "baseball-game"
   },
   {
-    "code": "binary-number-with-alternating-bits",
-    "problemNumber": 693,
-    "name": "Binary Number with Alternating Bits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 693,
+    "title": "Binary Number with Alternating Bits",
+    "titleSlug": "binary-number-with-alternating-bits"
   },
   {
-    "code": "count-binary-substrings",
-    "problemNumber": 696,
-    "name": "Count Binary Substrings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 696,
+    "title": "Count Binary Substrings",
+    "titleSlug": "count-binary-substrings"
   },
   {
-    "code": "degree-of-an-array",
-    "problemNumber": 697,
-    "name": "Degree of an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 697,
+    "title": "Degree of an Array",
+    "titleSlug": "degree-of-an-array"
   },
   {
-    "code": "search-in-a-binary-search-tree",
-    "problemNumber": 700,
-    "name": "Search in a Binary Search Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 700,
+    "title": "Search in a Binary Search Tree",
+    "titleSlug": "search-in-a-binary-search-tree"
   },
   {
-    "code": "kth-largest-element-in-a-stream",
-    "problemNumber": 703,
-    "name": "Kth Largest Element in a Stream",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 703,
+    "title": "Kth Largest Element in a Stream",
+    "titleSlug": "kth-largest-element-in-a-stream"
   },
   {
-    "code": "binary-search",
-    "problemNumber": 704,
-    "name": "Binary Search",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 704,
+    "title": "Binary Search",
+    "titleSlug": "binary-search"
   },
   {
-    "code": "design-hashset",
-    "problemNumber": 705,
-    "name": "Design HashSet",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 705,
+    "title": "Design HashSet",
+    "titleSlug": "design-hashset"
   },
   {
-    "code": "design-hashmap",
-    "problemNumber": 706,
-    "name": "Design HashMap",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 706,
+    "title": "Design HashMap",
+    "titleSlug": "design-hashmap"
   },
   {
-    "code": "to-lower-case",
-    "problemNumber": 709,
-    "name": "To Lower Case",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 709,
+    "title": "To Lower Case",
+    "titleSlug": "to-lower-case"
   },
   {
-    "code": "1-bit-and-2-bit-characters",
-    "problemNumber": 717,
-    "name": "1-bit and 2-bit Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 717,
+    "title": "1-bit and 2-bit Characters",
+    "titleSlug": "1-bit-and-2-bit-characters"
   },
   {
-    "code": "find-pivot-index",
-    "problemNumber": 724,
-    "name": "Find Pivot Index",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 724,
+    "title": "Find Pivot Index",
+    "titleSlug": "find-pivot-index"
   },
   {
-    "code": "self-dividing-numbers",
-    "problemNumber": 728,
-    "name": "Self Dividing Numbers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 728,
+    "title": "Self Dividing Numbers",
+    "titleSlug": "self-dividing-numbers"
   },
   {
-    "code": "flood-fill",
-    "problemNumber": 733,
-    "name": "Flood Fill",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 733,
+    "title": "Flood Fill",
+    "titleSlug": "flood-fill"
   },
   {
-    "code": "sentence-similarity",
-    "problemNumber": 734,
-    "name": "Sentence Similarity",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 734,
+    "title": "Sentence Similarity",
+    "titleSlug": "sentence-similarity"
   },
   {
-    "code": "find-smallest-letter-greater-than-target",
-    "problemNumber": 744,
-    "name": "Find Smallest Letter Greater Than Target",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 744,
+    "title": "Find Smallest Letter Greater Than Target",
+    "titleSlug": "find-smallest-letter-greater-than-target"
   },
   {
-    "code": "min-cost-climbing-stairs",
-    "problemNumber": 746,
-    "name": "Min Cost Climbing Stairs",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 746,
+    "title": "Min Cost Climbing Stairs",
+    "titleSlug": "min-cost-climbing-stairs"
   },
   {
-    "code": "largest-number-at-least-twice-of-others",
-    "problemNumber": 747,
-    "name": "Largest Number At Least Twice of Others",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 747,
+    "title": "Largest Number At Least Twice of Others",
+    "titleSlug": "largest-number-at-least-twice-of-others"
   },
   {
-    "code": "shortest-completing-word",
-    "problemNumber": 748,
-    "name": "Shortest Completing Word",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 748,
+    "title": "Shortest Completing Word",
+    "titleSlug": "shortest-completing-word"
   },
   {
-    "code": "find-anagram-mappings",
-    "problemNumber": 760,
-    "name": "Find Anagram Mappings",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 760,
+    "title": "Find Anagram Mappings",
+    "titleSlug": "find-anagram-mappings"
   },
   {
-    "code": "prime-number-of-set-bits-in-binary-representation",
-    "problemNumber": 762,
-    "name": "Prime Number of Set Bits in Binary Representation",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 762,
+    "title": "Prime Number of Set Bits in Binary Representation",
+    "titleSlug": "prime-number-of-set-bits-in-binary-representation"
   },
   {
-    "code": "toeplitz-matrix",
-    "problemNumber": 766,
-    "name": "Toeplitz Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 766,
+    "title": "Toeplitz Matrix",
+    "titleSlug": "toeplitz-matrix"
   },
   {
-    "code": "jewels-and-stones",
-    "problemNumber": 771,
-    "name": "Jewels and Stones",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 771,
+    "title": "Jewels and Stones",
+    "titleSlug": "jewels-and-stones"
   },
   {
-    "code": "minimum-distance-between-bst-nodes",
-    "problemNumber": 783,
-    "name": "Minimum Distance Between BST Nodes",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 783,
+    "title": "Minimum Distance Between BST Nodes",
+    "titleSlug": "minimum-distance-between-bst-nodes"
   },
   {
-    "code": "rotate-string",
-    "problemNumber": 796,
-    "name": "Rotate String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 796,
+    "title": "Rotate String",
+    "titleSlug": "rotate-string"
   },
   {
-    "code": "similar-rgb-color",
-    "problemNumber": 800,
-    "name": "Similar RGB Color",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 800,
+    "title": "Similar RGB Color",
+    "titleSlug": "similar-rgb-color"
   },
   {
-    "code": "unique-morse-code-words",
-    "problemNumber": 804,
-    "name": "Unique Morse Code Words",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 804,
+    "title": "Unique Morse Code Words",
+    "titleSlug": "unique-morse-code-words"
   },
   {
-    "code": "number-of-lines-to-write-string",
-    "problemNumber": 806,
-    "name": "Number of Lines To Write String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 806,
+    "title": "Number of Lines To Write String",
+    "titleSlug": "number-of-lines-to-write-string"
   },
   {
-    "code": "largest-triangle-area",
-    "problemNumber": 812,
-    "name": "Largest Triangle Area",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 812,
+    "title": "Largest Triangle Area",
+    "titleSlug": "largest-triangle-area"
   },
   {
-    "code": "most-common-word",
-    "problemNumber": 819,
-    "name": "Most Common Word",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 819,
+    "title": "Most Common Word",
+    "titleSlug": "most-common-word"
   },
   {
-    "code": "shortest-distance-to-a-character",
-    "problemNumber": 821,
-    "name": "Shortest Distance to a Character",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 821,
+    "title": "Shortest Distance to a Character",
+    "titleSlug": "shortest-distance-to-a-character"
   },
   {
-    "code": "goat-latin",
-    "problemNumber": 824,
-    "name": "Goat Latin",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 824,
+    "title": "Goat Latin",
+    "titleSlug": "goat-latin"
   },
   {
-    "code": "positions-of-large-groups",
-    "problemNumber": 830,
-    "name": "Positions of Large Groups",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 830,
+    "title": "Positions of Large Groups",
+    "titleSlug": "positions-of-large-groups"
   },
   {
-    "code": "flipping-an-image",
-    "problemNumber": 832,
-    "name": "Flipping an Image",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 832,
+    "title": "Flipping an Image",
+    "titleSlug": "flipping-an-image"
   },
   {
-    "code": "rectangle-overlap",
-    "problemNumber": 836,
-    "name": "Rectangle Overlap",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 836,
+    "title": "Rectangle Overlap",
+    "titleSlug": "rectangle-overlap"
   },
   {
-    "code": "backspace-string-compare",
-    "problemNumber": 844,
-    "name": "Backspace String Compare",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 844,
+    "title": "Backspace String Compare",
+    "titleSlug": "backspace-string-compare"
   },
   {
-    "code": "buddy-strings",
-    "problemNumber": 859,
-    "name": "Buddy Strings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 859,
+    "title": "Buddy Strings",
+    "titleSlug": "buddy-strings"
   },
   {
-    "code": "lemonade-change",
-    "problemNumber": 860,
-    "name": "Lemonade Change",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 860,
+    "title": "Lemonade Change",
+    "titleSlug": "lemonade-change"
   },
   {
-    "code": "transpose-matrix",
-    "problemNumber": 867,
-    "name": "Transpose Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 867,
+    "title": "Transpose Matrix",
+    "titleSlug": "transpose-matrix"
   },
   {
-    "code": "binary-gap",
-    "problemNumber": 868,
-    "name": "Binary Gap",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 868,
+    "title": "Binary Gap",
+    "titleSlug": "binary-gap"
   },
   {
-    "code": "leaf-similar-trees",
-    "problemNumber": 872,
-    "name": "Leaf-Similar Trees",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 872,
+    "title": "Leaf-Similar Trees",
+    "titleSlug": "leaf-similar-trees"
   },
   {
-    "code": "middle-of-the-linked-list",
-    "problemNumber": 876,
-    "name": "Middle of the Linked List",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 876,
+    "title": "Middle of the Linked List",
+    "titleSlug": "middle-of-the-linked-list"
   },
   {
-    "code": "projection-area-of-3d-shapes",
-    "problemNumber": 883,
-    "name": "Projection Area of 3D Shapes",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 883,
+    "title": "Projection Area of 3D Shapes",
+    "titleSlug": "projection-area-of-3d-shapes"
   },
   {
-    "code": "uncommon-words-from-two-sentences",
-    "problemNumber": 884,
-    "name": "Uncommon Words from Two Sentences",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 884,
+    "title": "Uncommon Words from Two Sentences",
+    "titleSlug": "uncommon-words-from-two-sentences"
   },
   {
-    "code": "fair-candy-swap",
-    "problemNumber": 888,
-    "name": "Fair Candy Swap",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 888,
+    "title": "Fair Candy Swap",
+    "titleSlug": "fair-candy-swap"
   },
   {
-    "code": "surface-area-of-3d-shapes",
-    "problemNumber": 892,
-    "name": "Surface Area of 3D Shapes",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 892,
+    "title": "Surface Area of 3D Shapes",
+    "titleSlug": "surface-area-of-3d-shapes"
   },
   {
-    "code": "monotonic-array",
-    "problemNumber": 896,
-    "name": "Monotonic Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 896,
+    "title": "Monotonic Array",
+    "titleSlug": "monotonic-array"
   },
   {
-    "code": "increasing-order-search-tree",
-    "problemNumber": 897,
-    "name": "Increasing Order Search Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 897,
+    "title": "Increasing Order Search Tree",
+    "titleSlug": "increasing-order-search-tree"
   },
   {
-    "code": "sort-array-by-parity",
-    "problemNumber": 905,
-    "name": "Sort Array By Parity",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 905,
+    "title": "Sort Array By Parity",
+    "titleSlug": "sort-array-by-parity"
   },
   {
-    "code": "smallest-range-i",
-    "problemNumber": 908,
-    "name": "Smallest Range I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 908,
+    "title": "Smallest Range I",
+    "titleSlug": "smallest-range-i"
   },
   {
-    "code": "x-of-a-kind-in-a-deck-of-cards",
-    "problemNumber": 914,
-    "name": "X of a Kind in a Deck of Cards",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 914,
+    "title": "X of a Kind in a Deck of Cards",
+    "titleSlug": "x-of-a-kind-in-a-deck-of-cards"
   },
   {
-    "code": "reverse-only-letters",
-    "problemNumber": 917,
-    "name": "Reverse Only Letters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 917,
+    "title": "Reverse Only Letters",
+    "titleSlug": "reverse-only-letters"
   },
   {
-    "code": "sort-array-by-parity-ii",
-    "problemNumber": 922,
-    "name": "Sort Array By Parity II",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 922,
+    "title": "Sort Array By Parity II",
+    "titleSlug": "sort-array-by-parity-ii"
   },
   {
-    "code": "long-pressed-name",
-    "problemNumber": 925,
-    "name": "Long Pressed Name",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 925,
+    "title": "Long Pressed Name",
+    "titleSlug": "long-pressed-name"
   },
   {
-    "code": "unique-email-addresses",
-    "problemNumber": 929,
-    "name": "Unique Email Addresses",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 929,
+    "title": "Unique Email Addresses",
+    "titleSlug": "unique-email-addresses"
   },
   {
-    "code": "number-of-recent-calls",
-    "problemNumber": 933,
-    "name": "Number of Recent Calls",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 933,
+    "title": "Number of Recent Calls",
+    "titleSlug": "number-of-recent-calls"
   },
   {
-    "code": "range-sum-of-bst",
-    "problemNumber": 938,
-    "name": "Range Sum of BST",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 938,
+    "title": "Range Sum of BST",
+    "titleSlug": "range-sum-of-bst"
   },
   {
-    "code": "valid-mountain-array",
-    "problemNumber": 941,
-    "name": "Valid Mountain Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 941,
+    "title": "Valid Mountain Array",
+    "titleSlug": "valid-mountain-array"
   },
   {
-    "code": "di-string-match",
-    "problemNumber": 942,
-    "name": "DI String Match",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 942,
+    "title": "DI String Match",
+    "titleSlug": "di-string-match"
   },
   {
-    "code": "delete-columns-to-make-sorted",
-    "problemNumber": 944,
-    "name": "Delete Columns to Make Sorted",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 944,
+    "title": "Delete Columns to Make Sorted",
+    "titleSlug": "delete-columns-to-make-sorted"
   },
   {
-    "code": "verifying-an-alien-dictionary",
-    "problemNumber": 953,
-    "name": "Verifying an Alien Dictionary",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 953,
+    "title": "Verifying an Alien Dictionary",
+    "titleSlug": "verifying-an-alien-dictionary"
   },
   {
-    "code": "n-repeated-element-in-size-2n-array",
-    "problemNumber": 961,
-    "name": "N-Repeated Element in Size 2N Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 961,
+    "title": "N-Repeated Element in Size 2N Array",
+    "titleSlug": "n-repeated-element-in-size-2n-array"
   },
   {
-    "code": "univalued-binary-tree",
-    "problemNumber": 965,
-    "name": "Univalued Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 965,
+    "title": "Univalued Binary Tree",
+    "titleSlug": "univalued-binary-tree"
   },
   {
-    "code": "largest-perimeter-triangle",
-    "problemNumber": 976,
-    "name": "Largest Perimeter Triangle",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 976,
+    "title": "Largest Perimeter Triangle",
+    "titleSlug": "largest-perimeter-triangle"
   },
   {
-    "code": "squares-of-a-sorted-array",
-    "problemNumber": 977,
-    "name": "Squares of a Sorted Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 977,
+    "title": "Squares of a Sorted Array",
+    "titleSlug": "squares-of-a-sorted-array"
   },
   {
-    "code": "add-to-array-form-of-integer",
-    "problemNumber": 989,
-    "name": "Add to Array-Form of Integer",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 989,
+    "title": "Add to Array-Form of Integer",
+    "titleSlug": "add-to-array-form-of-integer"
   },
   {
-    "code": "cousins-in-binary-tree",
-    "problemNumber": 993,
-    "name": "Cousins in Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 993,
+    "title": "Cousins in Binary Tree",
+    "titleSlug": "cousins-in-binary-tree"
   },
   {
-    "code": "find-the-town-judge",
-    "problemNumber": 997,
-    "name": "Find the Town Judge",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 997,
+    "title": "Find the Town Judge",
+    "titleSlug": "find-the-town-judge"
   },
   {
-    "code": "available-captures-for-rook",
-    "problemNumber": 999,
-    "name": "Available Captures for Rook",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 999,
+    "title": "Available Captures for Rook",
+    "titleSlug": "available-captures-for-rook"
   },
   {
-    "code": "find-common-characters",
-    "problemNumber": 1002,
-    "name": "Find Common Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1002,
+    "title": "Find Common Characters",
+    "titleSlug": "find-common-characters"
   },
   {
-    "code": "maximize-sum-of-array-after-k-negations",
-    "problemNumber": 1005,
-    "name": "Maximize Sum Of Array After K Negations",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1005,
+    "title": "Maximize Sum Of Array After K Negations",
+    "titleSlug": "maximize-sum-of-array-after-k-negations"
   },
   {
-    "code": "complement-of-base-10-integer",
-    "problemNumber": 1009,
-    "name": "Complement of Base 10 Integer",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1009,
+    "title": "Complement of Base 10 Integer",
+    "titleSlug": "complement-of-base-10-integer"
   },
   {
-    "code": "partition-array-into-three-parts-with-equal-sum",
-    "problemNumber": 1013,
-    "name": "Partition Array Into Three Parts With Equal Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1013,
+    "title": "Partition Array Into Three Parts With Equal Sum",
+    "titleSlug": "partition-array-into-three-parts-with-equal-sum"
   },
   {
-    "code": "binary-prefix-divisible-by-5",
-    "problemNumber": 1018,
-    "name": "Binary Prefix Divisible By 5",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1018,
+    "title": "Binary Prefix Divisible By 5",
+    "titleSlug": "binary-prefix-divisible-by-5"
   },
   {
-    "code": "remove-outermost-parentheses",
-    "problemNumber": 1021,
-    "name": "Remove Outermost Parentheses",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1021,
+    "title": "Remove Outermost Parentheses",
+    "titleSlug": "remove-outermost-parentheses"
   },
   {
-    "code": "sum-of-root-to-leaf-binary-numbers",
-    "problemNumber": 1022,
-    "name": "Sum of Root To Leaf Binary Numbers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1022,
+    "title": "Sum of Root To Leaf Binary Numbers",
+    "titleSlug": "sum-of-root-to-leaf-binary-numbers"
   },
   {
-    "code": "divisor-game",
-    "problemNumber": 1025,
-    "name": "Divisor Game",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1025,
+    "title": "Divisor Game",
+    "titleSlug": "divisor-game"
   },
   {
-    "code": "matrix-cells-in-distance-order",
-    "problemNumber": 1030,
-    "name": "Matrix Cells in Distance Order",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1030,
+    "title": "Matrix Cells in Distance Order",
+    "titleSlug": "matrix-cells-in-distance-order"
   },
   {
-    "code": "valid-boomerang",
-    "problemNumber": 1037,
-    "name": "Valid Boomerang",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1037,
+    "title": "Valid Boomerang",
+    "titleSlug": "valid-boomerang"
   },
   {
-    "code": "last-stone-weight",
-    "problemNumber": 1046,
-    "name": "Last Stone Weight",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1046,
+    "title": "Last Stone Weight",
+    "titleSlug": "last-stone-weight"
   },
   {
-    "code": "remove-all-adjacent-duplicates-in-string",
-    "problemNumber": 1047,
-    "name": "Remove All Adjacent Duplicates In String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1047,
+    "title": "Remove All Adjacent Duplicates In String",
+    "titleSlug": "remove-all-adjacent-duplicates-in-string"
   },
   {
-    "code": "height-checker",
-    "problemNumber": 1051,
-    "name": "Height Checker",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1051,
+    "title": "Height Checker",
+    "titleSlug": "height-checker"
   },
   {
-    "code": "confusing-number",
-    "problemNumber": 1056,
-    "name": "Confusing Number",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1056,
+    "title": "Confusing Number",
+    "titleSlug": "confusing-number"
   },
   {
-    "code": "fixed-point",
-    "problemNumber": 1064,
-    "name": "Fixed Point",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1064,
+    "title": "Fixed Point",
+    "titleSlug": "fixed-point"
   },
   {
-    "code": "index-pairs-of-a-string",
-    "problemNumber": 1065,
-    "name": "Index Pairs of a String",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1065,
+    "title": "Index Pairs of a String",
+    "titleSlug": "index-pairs-of-a-string"
   },
   {
-    "code": "greatest-common-divisor-of-strings",
-    "problemNumber": 1071,
-    "name": "Greatest Common Divisor of Strings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1071,
+    "title": "Greatest Common Divisor of Strings",
+    "titleSlug": "greatest-common-divisor-of-strings"
   },
   {
-    "code": "occurrences-after-bigram",
-    "problemNumber": 1078,
-    "name": "Occurrences After Bigram",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1078,
+    "title": "Occurrences After Bigram",
+    "titleSlug": "occurrences-after-bigram"
   },
   {
-    "code": "sum-of-digits-in-the-minimum-number",
-    "problemNumber": 1085,
-    "name": "Sum of Digits in the Minimum Number",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1085,
+    "title": "Sum of Digits in the Minimum Number",
+    "titleSlug": "sum-of-digits-in-the-minimum-number"
   },
   {
-    "code": "high-five",
-    "problemNumber": 1086,
-    "name": "High Five",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1086,
+    "title": "High Five",
+    "titleSlug": "high-five"
   },
   {
-    "code": "duplicate-zeros",
-    "problemNumber": 1089,
-    "name": "Duplicate Zeros",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1089,
+    "title": "Duplicate Zeros",
+    "titleSlug": "duplicate-zeros"
   },
   {
-    "code": "two-sum-less-than-k",
-    "problemNumber": 1099,
-    "name": "Two Sum Less Than K",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1099,
+    "title": "Two Sum Less Than K",
+    "titleSlug": "two-sum-less-than-k"
   },
   {
-    "code": "distribute-candies-to-people",
-    "problemNumber": 1103,
-    "name": "Distribute Candies to People",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1103,
+    "title": "Distribute Candies to People",
+    "titleSlug": "distribute-candies-to-people"
   },
   {
-    "code": "defanging-an-ip-address",
-    "problemNumber": 1108,
-    "name": "Defanging an IP Address",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1108,
+    "title": "Defanging an IP Address",
+    "titleSlug": "defanging-an-ip-address"
   },
   {
-    "code": "number-of-days-in-a-month",
-    "problemNumber": 1118,
-    "name": "Number of Days in a Month",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1118,
+    "title": "Number of Days in a Month",
+    "titleSlug": "number-of-days-in-a-month"
   },
   {
-    "code": "remove-vowels-from-a-string",
-    "problemNumber": 1119,
-    "name": "Remove Vowels from a String",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1119,
+    "title": "Remove Vowels from a String",
+    "titleSlug": "remove-vowels-from-a-string"
   },
   {
-    "code": "relative-sort-array",
-    "problemNumber": 1122,
-    "name": "Relative Sort Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1122,
+    "title": "Relative Sort Array",
+    "titleSlug": "relative-sort-array"
   },
   {
-    "code": "number-of-equivalent-domino-pairs",
-    "problemNumber": 1128,
-    "name": "Number of Equivalent Domino Pairs",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1128,
+    "title": "Number of Equivalent Domino Pairs",
+    "titleSlug": "number-of-equivalent-domino-pairs"
   },
   {
-    "code": "largest-unique-number",
-    "problemNumber": 1133,
-    "name": "Largest Unique Number",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1133,
+    "title": "Largest Unique Number",
+    "titleSlug": "largest-unique-number"
   },
   {
-    "code": "armstrong-number",
-    "problemNumber": 1134,
-    "name": "Armstrong Number",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1134,
+    "title": "Armstrong Number",
+    "titleSlug": "armstrong-number"
   },
   {
-    "code": "n-th-tribonacci-number",
-    "problemNumber": 1137,
-    "name": "N-th Tribonacci Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1137,
+    "title": "N-th Tribonacci Number",
+    "titleSlug": "n-th-tribonacci-number"
   },
   {
-    "code": "check-if-a-number-is-majority-element-in-a-sorted-array",
-    "problemNumber": 1150,
-    "name": "Check If a Number Is Majority Element in a Sorted Array",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1150,
+    "title": "Check If a Number Is Majority Element in a Sorted Array",
+    "titleSlug": "check-if-a-number-is-majority-element-in-a-sorted-array"
   },
   {
-    "code": "day-of-the-year",
-    "problemNumber": 1154,
-    "name": "Day of the Year",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1154,
+    "title": "Day of the Year",
+    "titleSlug": "day-of-the-year"
   },
   {
-    "code": "find-words-that-can-be-formed-by-characters",
-    "problemNumber": 1160,
-    "name": "Find Words That Can Be Formed by Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1160,
+    "title": "Find Words That Can Be Formed by Characters",
+    "titleSlug": "find-words-that-can-be-formed-by-characters"
   },
   {
-    "code": "single-row-keyboard",
-    "problemNumber": 1165,
-    "name": "Single-Row Keyboard",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1165,
+    "title": "Single-Row Keyboard",
+    "titleSlug": "single-row-keyboard"
   },
   {
-    "code": "prime-arrangements",
-    "problemNumber": 1175,
-    "name": "Prime Arrangements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1175,
+    "title": "Prime Arrangements",
+    "titleSlug": "prime-arrangements"
   },
   {
-    "code": "diet-plan-performance",
-    "problemNumber": 1176,
-    "name": "Diet Plan Performance",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1176,
+    "title": "Diet Plan Performance",
+    "titleSlug": "diet-plan-performance"
   },
   {
-    "code": "count-substrings-with-only-one-distinct-letter",
-    "problemNumber": 1180,
-    "name": "Count Substrings with Only One Distinct Letter",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1180,
+    "title": "Count Substrings with Only One Distinct Letter",
+    "titleSlug": "count-substrings-with-only-one-distinct-letter"
   },
   {
-    "code": "distance-between-bus-stops",
-    "problemNumber": 1184,
-    "name": "Distance Between Bus Stops",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1184,
+    "title": "Distance Between Bus Stops",
+    "titleSlug": "distance-between-bus-stops"
   },
   {
-    "code": "day-of-the-week",
-    "problemNumber": 1185,
-    "name": "Day of the Week",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1185,
+    "title": "Day of the Week",
+    "titleSlug": "day-of-the-week"
   },
   {
-    "code": "maximum-number-of-balloons",
-    "problemNumber": 1189,
-    "name": "Maximum Number of Balloons",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1189,
+    "title": "Maximum Number of Balloons",
+    "titleSlug": "maximum-number-of-balloons"
   },
   {
-    "code": "how-many-apples-can-you-put-into-the-basket",
-    "problemNumber": 1196,
-    "name": "How Many Apples Can You Put into the Basket",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1196,
+    "title": "How Many Apples Can You Put into the Basket",
+    "titleSlug": "how-many-apples-can-you-put-into-the-basket"
   },
   {
-    "code": "minimum-absolute-difference",
-    "problemNumber": 1200,
-    "name": "Minimum Absolute Difference",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1200,
+    "title": "Minimum Absolute Difference",
+    "titleSlug": "minimum-absolute-difference"
   },
   {
-    "code": "unique-number-of-occurrences",
-    "problemNumber": 1207,
-    "name": "Unique Number of Occurrences",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1207,
+    "title": "Unique Number of Occurrences",
+    "titleSlug": "unique-number-of-occurrences"
   },
   {
-    "code": "intersection-of-three-sorted-arrays",
-    "problemNumber": 1213,
-    "name": "Intersection of Three Sorted Arrays",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1213,
+    "title": "Intersection of Three Sorted Arrays",
+    "titleSlug": "intersection-of-three-sorted-arrays"
   },
   {
-    "code": "minimum-cost-to-move-chips-to-the-same-position",
-    "problemNumber": 1217,
-    "name": "Minimum Cost to Move Chips to The Same Position",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1217,
+    "title": "Minimum Cost to Move Chips to The Same Position",
+    "titleSlug": "minimum-cost-to-move-chips-to-the-same-position"
   },
   {
-    "code": "split-a-string-in-balanced-strings",
-    "problemNumber": 1221,
-    "name": "Split a String in Balanced Strings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1221,
+    "title": "Split a String in Balanced Strings",
+    "titleSlug": "split-a-string-in-balanced-strings"
   },
   {
-    "code": "missing-number-in-arithmetic-progression",
-    "problemNumber": 1228,
-    "name": "Missing Number In Arithmetic Progression",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1228,
+    "title": "Missing Number In Arithmetic Progression",
+    "titleSlug": "missing-number-in-arithmetic-progression"
   },
   {
-    "code": "check-if-it-is-a-straight-line",
-    "problemNumber": 1232,
-    "name": "Check If It Is a Straight Line",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1232,
+    "title": "Check If It Is a Straight Line",
+    "titleSlug": "check-if-it-is-a-straight-line"
   },
   {
-    "code": "array-transformation",
-    "problemNumber": 1243,
-    "name": "Array Transformation",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1243,
+    "title": "Array Transformation",
+    "titleSlug": "array-transformation"
   },
   {
-    "code": "cells-with-odd-values-in-a-matrix",
-    "problemNumber": 1252,
-    "name": "Cells with Odd Values in a Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1252,
+    "title": "Cells with Odd Values in a Matrix",
+    "titleSlug": "cells-with-odd-values-in-a-matrix"
   },
   {
-    "code": "shift-2d-grid",
-    "problemNumber": 1260,
-    "name": "Shift 2D Grid",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1260,
+    "title": "Shift 2D Grid",
+    "titleSlug": "shift-2d-grid"
   },
   {
-    "code": "minimum-time-visiting-all-points",
-    "problemNumber": 1266,
-    "name": "Minimum Time Visiting All Points",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1266,
+    "title": "Minimum Time Visiting All Points",
+    "titleSlug": "minimum-time-visiting-all-points"
   },
   {
-    "code": "hexspeak",
-    "problemNumber": 1271,
-    "name": "Hexspeak",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1271,
+    "title": "Hexspeak",
+    "titleSlug": "hexspeak"
   },
   {
-    "code": "find-winner-on-a-tic-tac-toe-game",
-    "problemNumber": 1275,
-    "name": "Find Winner on a Tic Tac Toe Game",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1275,
+    "title": "Find Winner on a Tic Tac Toe Game",
+    "titleSlug": "find-winner-on-a-tic-tac-toe-game"
   },
   {
-    "code": "subtract-the-product-and-sum-of-digits-of-an-integer",
-    "problemNumber": 1281,
-    "name": "Subtract the Product and Sum of Digits of an Integer",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1281,
+    "title": "Subtract the Product and Sum of Digits of an Integer",
+    "titleSlug": "subtract-the-product-and-sum-of-digits-of-an-integer"
   },
   {
-    "code": "element-appearing-more-than-25-in-sorted-array",
-    "problemNumber": 1287,
-    "name": "Element Appearing More Than 25% In Sorted Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1287,
+    "title": "Element Appearing More Than 25% In Sorted Array",
+    "titleSlug": "element-appearing-more-than-25-in-sorted-array"
   },
   {
-    "code": "convert-binary-number-in-a-linked-list-to-integer",
-    "problemNumber": 1290,
-    "name": "Convert Binary Number in a Linked List to Integer",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1290,
+    "title": "Convert Binary Number in a Linked List to Integer",
+    "titleSlug": "convert-binary-number-in-a-linked-list-to-integer"
   },
   {
-    "code": "find-numbers-with-even-number-of-digits",
-    "problemNumber": 1295,
-    "name": "Find Numbers with Even Number of Digits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1295,
+    "title": "Find Numbers with Even Number of Digits",
+    "titleSlug": "find-numbers-with-even-number-of-digits"
   },
   {
-    "code": "replace-elements-with-greatest-element-on-right-side",
-    "problemNumber": 1299,
-    "name": "Replace Elements with Greatest Element on Right Side",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1299,
+    "title": "Replace Elements with Greatest Element on Right Side",
+    "titleSlug": "replace-elements-with-greatest-element-on-right-side"
   },
   {
-    "code": "find-n-unique-integers-sum-up-to-zero",
-    "problemNumber": 1304,
-    "name": "Find N Unique Integers Sum up to Zero",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1304,
+    "title": "Find N Unique Integers Sum up to Zero",
+    "titleSlug": "find-n-unique-integers-sum-up-to-zero"
   },
   {
-    "code": "decrypt-string-from-alphabet-to-integer-mapping",
-    "problemNumber": 1309,
-    "name": "Decrypt String from Alphabet to Integer Mapping",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1309,
+    "title": "Decrypt String from Alphabet to Integer Mapping",
+    "titleSlug": "decrypt-string-from-alphabet-to-integer-mapping"
   },
   {
-    "code": "decompress-run-length-encoded-list",
-    "problemNumber": 1313,
-    "name": "Decompress Run-Length Encoded List",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1313,
+    "title": "Decompress Run-Length Encoded List",
+    "titleSlug": "decompress-run-length-encoded-list"
   },
   {
-    "code": "convert-integer-to-the-sum-of-two-no-zero-integers",
-    "problemNumber": 1317,
-    "name": "Convert Integer to the Sum of Two No-Zero Integers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1317,
+    "title": "Convert Integer to the Sum of Two No-Zero Integers",
+    "titleSlug": "convert-integer-to-the-sum-of-two-no-zero-integers"
   },
   {
-    "code": "maximum-69-number",
-    "problemNumber": 1323,
-    "name": "Maximum 69 Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1323,
+    "title": "Maximum 69 Number",
+    "titleSlug": "maximum-69-number"
   },
   {
-    "code": "rank-transform-of-an-array",
-    "problemNumber": 1331,
-    "name": "Rank Transform of an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1331,
+    "title": "Rank Transform of an Array",
+    "titleSlug": "rank-transform-of-an-array"
   },
   {
-    "code": "remove-palindromic-subsequences",
-    "problemNumber": 1332,
-    "name": "Remove Palindromic Subsequences",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1332,
+    "title": "Remove Palindromic Subsequences",
+    "titleSlug": "remove-palindromic-subsequences"
   },
   {
-    "code": "the-k-weakest-rows-in-a-matrix",
-    "problemNumber": 1337,
-    "name": "The K Weakest Rows in a Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1337,
+    "title": "The K Weakest Rows in a Matrix",
+    "titleSlug": "the-k-weakest-rows-in-a-matrix"
   },
   {
-    "code": "number-of-steps-to-reduce-a-number-to-zero",
-    "problemNumber": 1342,
-    "name": "Number of Steps to Reduce a Number to Zero",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1342,
+    "title": "Number of Steps to Reduce a Number to Zero",
+    "titleSlug": "number-of-steps-to-reduce-a-number-to-zero"
   },
   {
-    "code": "check-if-n-and-its-double-exist",
-    "problemNumber": 1346,
-    "name": "Check If N and Its Double Exist",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1346,
+    "title": "Check If N and Its Double Exist",
+    "titleSlug": "check-if-n-and-its-double-exist"
   },
   {
-    "code": "count-negative-numbers-in-a-sorted-matrix",
-    "problemNumber": 1351,
-    "name": "Count Negative Numbers in a Sorted Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1351,
+    "title": "Count Negative Numbers in a Sorted Matrix",
+    "titleSlug": "count-negative-numbers-in-a-sorted-matrix"
   },
   {
-    "code": "sort-integers-by-the-number-of-1-bits",
-    "problemNumber": 1356,
-    "name": "Sort Integers by The Number of 1 Bits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1356,
+    "title": "Sort Integers by The Number of 1 Bits",
+    "titleSlug": "sort-integers-by-the-number-of-1-bits"
   },
   {
-    "code": "number-of-days-between-two-dates",
-    "problemNumber": 1360,
-    "name": "Number of Days Between Two Dates",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1360,
+    "title": "Number of Days Between Two Dates",
+    "titleSlug": "number-of-days-between-two-dates"
   },
   {
-    "code": "how-many-numbers-are-smaller-than-the-current-number",
-    "problemNumber": 1365,
-    "name": "How Many Numbers Are Smaller Than the Current Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1365,
+    "title": "How Many Numbers Are Smaller Than the Current Number",
+    "titleSlug": "how-many-numbers-are-smaller-than-the-current-number"
   },
   {
-    "code": "increasing-decreasing-string",
-    "problemNumber": 1370,
-    "name": "Increasing Decreasing String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1370,
+    "title": "Increasing Decreasing String",
+    "titleSlug": "increasing-decreasing-string"
   },
   {
-    "code": "generate-a-string-with-characters-that-have-odd-counts",
-    "problemNumber": 1374,
-    "name": "Generate a String With Characters That Have Odd Counts",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1374,
+    "title": "Generate a String With Characters That Have Odd Counts",
+    "titleSlug": "generate-a-string-with-characters-that-have-odd-counts"
   },
   {
-    "code": "find-a-corresponding-node-of-a-binary-tree-in-a-clone-of-that-tree",
-    "problemNumber": 1379,
-    "name": "Find a Corresponding Node of a Binary Tree in a Clone of That Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1379,
+    "title": "Find a Corresponding Node of a Binary Tree in a Clone of That Tree",
+    "titleSlug": "find-a-corresponding-node-of-a-binary-tree-in-a-clone-of-that-tree"
   },
   {
-    "code": "lucky-numbers-in-a-matrix",
-    "problemNumber": 1380,
-    "name": "Lucky Numbers in a Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1380,
+    "title": "Lucky Numbers in a Matrix",
+    "titleSlug": "lucky-numbers-in-a-matrix"
   },
   {
-    "code": "find-the-distance-value-between-two-arrays",
-    "problemNumber": 1385,
-    "name": "Find the Distance Value Between Two Arrays",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1385,
+    "title": "Find the Distance Value Between Two Arrays",
+    "titleSlug": "find-the-distance-value-between-two-arrays"
   },
   {
-    "code": "create-target-array-in-the-given-order",
-    "problemNumber": 1389,
-    "name": "Create Target Array in the Given Order",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1389,
+    "title": "Create Target Array in the Given Order",
+    "titleSlug": "create-target-array-in-the-given-order"
   },
   {
-    "code": "find-lucky-integer-in-an-array",
-    "problemNumber": 1394,
-    "name": "Find Lucky Integer in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1394,
+    "title": "Find Lucky Integer in an Array",
+    "titleSlug": "find-lucky-integer-in-an-array"
   },
   {
-    "code": "count-largest-group",
-    "problemNumber": 1399,
-    "name": "Count Largest Group",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1399,
+    "title": "Count Largest Group",
+    "titleSlug": "count-largest-group"
   },
   {
-    "code": "minimum-subsequence-in-non-increasing-order",
-    "problemNumber": 1403,
-    "name": "Minimum Subsequence in Non-Increasing Order",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1403,
+    "title": "Minimum Subsequence in Non-Increasing Order",
+    "titleSlug": "minimum-subsequence-in-non-increasing-order"
   },
   {
-    "code": "string-matching-in-an-array",
-    "problemNumber": 1408,
-    "name": "String Matching in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1408,
+    "title": "String Matching in an Array",
+    "titleSlug": "string-matching-in-an-array"
   },
   {
-    "code": "minimum-value-to-get-positive-step-by-step-sum",
-    "problemNumber": 1413,
-    "name": "Minimum Value to Get Positive Step by Step Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1413,
+    "title": "Minimum Value to Get Positive Step by Step Sum",
+    "titleSlug": "minimum-value-to-get-positive-step-by-step-sum"
   },
   {
-    "code": "reformat-the-string",
-    "problemNumber": 1417,
-    "name": "Reformat The String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1417,
+    "title": "Reformat The String",
+    "titleSlug": "reformat-the-string"
   },
   {
-    "code": "maximum-score-after-splitting-a-string",
-    "problemNumber": 1422,
-    "name": "Maximum Score After Splitting a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1422,
+    "title": "Maximum Score After Splitting a String",
+    "titleSlug": "maximum-score-after-splitting-a-string"
   },
   {
-    "code": "counting-elements",
-    "problemNumber": 1426,
-    "name": "Counting Elements",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1426,
+    "title": "Counting Elements",
+    "titleSlug": "counting-elements"
   },
   {
-    "code": "perform-string-shifts",
-    "problemNumber": 1427,
-    "name": "Perform String Shifts",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1427,
+    "title": "Perform String Shifts",
+    "titleSlug": "perform-string-shifts"
   },
   {
-    "code": "kids-with-the-greatest-number-of-candies",
-    "problemNumber": 1431,
-    "name": "Kids With the Greatest Number of Candies",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1431,
+    "title": "Kids With the Greatest Number of Candies",
+    "titleSlug": "kids-with-the-greatest-number-of-candies"
   },
   {
-    "code": "destination-city",
-    "problemNumber": 1436,
-    "name": "Destination City",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1436,
+    "title": "Destination City",
+    "titleSlug": "destination-city"
   },
   {
-    "code": "check-if-all-1s-are-at-least-length-k-places-away",
-    "problemNumber": 1437,
-    "name": "Check If All 1's Are at Least Length K Places Away",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1437,
+    "title": "Check If All 1's Are at Least Length K Places Away",
+    "titleSlug": "check-if-all-1s-are-at-least-length-k-places-away"
   },
   {
-    "code": "consecutive-characters",
-    "problemNumber": 1446,
-    "name": "Consecutive Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1446,
+    "title": "Consecutive Characters",
+    "titleSlug": "consecutive-characters"
   },
   {
-    "code": "number-of-students-doing-homework-at-a-given-time",
-    "problemNumber": 1450,
-    "name": "Number of Students Doing Homework at a Given Time",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1450,
+    "title": "Number of Students Doing Homework at a Given Time",
+    "titleSlug": "number-of-students-doing-homework-at-a-given-time"
   },
   {
-    "code": "check-if-a-word-occurs-as-a-prefix-of-any-word-in-a-sentence",
-    "problemNumber": 1455,
-    "name": "Check If a Word Occurs As a Prefix of Any Word in a Sentence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1455,
+    "title": "Check If a Word Occurs As a Prefix of Any Word in a Sentence",
+    "titleSlug": "check-if-a-word-occurs-as-a-prefix-of-any-word-in-a-sentence"
   },
   {
-    "code": "make-two-arrays-equal-by-reversing-subarrays",
-    "problemNumber": 1460,
-    "name": "Make Two Arrays Equal by Reversing Subarrays",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1460,
+    "title": "Make Two Arrays Equal by Reversing Subarrays",
+    "titleSlug": "make-two-arrays-equal-by-reversing-subarrays"
   },
   {
-    "code": "maximum-product-of-two-elements-in-an-array",
-    "problemNumber": 1464,
-    "name": "Maximum Product of Two Elements in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1464,
+    "title": "Maximum Product of Two Elements in an Array",
+    "titleSlug": "maximum-product-of-two-elements-in-an-array"
   },
   {
-    "code": "find-all-the-lonely-nodes",
-    "problemNumber": 1469,
-    "name": "Find All The Lonely Nodes",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1469,
+    "title": "Find All The Lonely Nodes",
+    "titleSlug": "find-all-the-lonely-nodes"
   },
   {
-    "code": "shuffle-the-array",
-    "problemNumber": 1470,
-    "name": "Shuffle the Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1470,
+    "title": "Shuffle the Array",
+    "titleSlug": "shuffle-the-array"
   },
   {
-    "code": "delete-n-nodes-after-m-nodes-of-a-linked-list",
-    "problemNumber": 1474,
-    "name": "Delete N Nodes After M Nodes of a Linked List",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1474,
+    "title": "Delete N Nodes After M Nodes of a Linked List",
+    "titleSlug": "delete-n-nodes-after-m-nodes-of-a-linked-list"
   },
   {
-    "code": "final-prices-with-a-special-discount-in-a-shop",
-    "problemNumber": 1475,
-    "name": "Final Prices With a Special Discount in a Shop",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1475,
+    "title": "Final Prices With a Special Discount in a Shop",
+    "titleSlug": "final-prices-with-a-special-discount-in-a-shop"
   },
   {
-    "code": "running-sum-of-1d-array",
-    "problemNumber": 1480,
-    "name": "Running Sum of 1d Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1480,
+    "title": "Running Sum of 1d Array",
+    "titleSlug": "running-sum-of-1d-array"
   },
   {
-    "code": "xor-operation-in-an-array",
-    "problemNumber": 1486,
-    "name": "XOR Operation in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1486,
+    "title": "XOR Operation in an Array",
+    "titleSlug": "xor-operation-in-an-array"
   },
   {
-    "code": "average-salary-excluding-the-minimum-and-maximum-salary",
-    "problemNumber": 1491,
-    "name": "Average Salary Excluding the Minimum and Maximum Salary",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1491,
+    "title": "Average Salary Excluding the Minimum and Maximum Salary",
+    "titleSlug": "average-salary-excluding-the-minimum-and-maximum-salary"
   },
   {
-    "code": "path-crossing",
-    "problemNumber": 1496,
-    "name": "Path Crossing",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1496,
+    "title": "Path Crossing",
+    "titleSlug": "path-crossing"
   },
   {
-    "code": "can-make-arithmetic-progression-from-sequence",
-    "problemNumber": 1502,
-    "name": "Can Make Arithmetic Progression From Sequence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1502,
+    "title": "Can Make Arithmetic Progression From Sequence",
+    "titleSlug": "can-make-arithmetic-progression-from-sequence"
   },
   {
-    "code": "reformat-date",
-    "problemNumber": 1507,
-    "name": "Reformat Date",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1507,
+    "title": "Reformat Date",
+    "titleSlug": "reformat-date"
   },
   {
-    "code": "number-of-good-pairs",
-    "problemNumber": 1512,
-    "name": "Number of Good Pairs",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1512,
+    "title": "Number of Good Pairs",
+    "titleSlug": "number-of-good-pairs"
   },
   {
-    "code": "water-bottles",
-    "problemNumber": 1518,
-    "name": "Water Bottles",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1518,
+    "title": "Water Bottles",
+    "titleSlug": "water-bottles"
   },
   {
-    "code": "count-odd-numbers-in-an-interval-range",
-    "problemNumber": 1523,
-    "name": "Count Odd Numbers in an Interval Range",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1523,
+    "title": "Count Odd Numbers in an Interval Range",
+    "titleSlug": "count-odd-numbers-in-an-interval-range"
   },
   {
-    "code": "shuffle-string",
-    "problemNumber": 1528,
-    "name": "Shuffle String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1528,
+    "title": "Shuffle String",
+    "titleSlug": "shuffle-string"
   },
   {
-    "code": "count-good-triplets",
-    "problemNumber": 1534,
-    "name": "Count Good Triplets",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1534,
+    "title": "Count Good Triplets",
+    "titleSlug": "count-good-triplets"
   },
   {
-    "code": "kth-missing-positive-number",
-    "problemNumber": 1539,
-    "name": "Kth Missing Positive Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1539,
+    "title": "Kth Missing Positive Number",
+    "titleSlug": "kth-missing-positive-number"
   },
   {
-    "code": "make-the-string-great",
-    "problemNumber": 1544,
-    "name": "Make The String Great",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1544,
+    "title": "Make The String Great",
+    "titleSlug": "make-the-string-great"
   },
   {
-    "code": "three-consecutive-odds",
-    "problemNumber": 1550,
-    "name": "Three Consecutive Odds",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1550,
+    "title": "Three Consecutive Odds",
+    "titleSlug": "three-consecutive-odds"
   },
   {
-    "code": "thousand-separator",
-    "problemNumber": 1556,
-    "name": "Thousand Separator",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1556,
+    "title": "Thousand Separator",
+    "titleSlug": "thousand-separator"
   },
   {
-    "code": "most-visited-sector-in-a-circular-track",
-    "problemNumber": 1560,
-    "name": "Most Visited Sector in  a Circular Track",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1560,
+    "title": "Most Visited Sector in  a Circular Track",
+    "titleSlug": "most-visited-sector-in-a-circular-track"
   },
   {
-    "code": "detect-pattern-of-length-m-repeated-k-or-more-times",
-    "problemNumber": 1566,
-    "name": "Detect Pattern of Length M Repeated K or More Times",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1566,
+    "title": "Detect Pattern of Length M Repeated K or More Times",
+    "titleSlug": "detect-pattern-of-length-m-repeated-k-or-more-times"
   },
   {
-    "code": "matrix-diagonal-sum",
-    "problemNumber": 1572,
-    "name": "Matrix Diagonal Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1572,
+    "title": "Matrix Diagonal Sum",
+    "titleSlug": "matrix-diagonal-sum"
   },
   {
-    "code": "replace-all-s-to-avoid-consecutive-repeating-characters",
-    "problemNumber": 1576,
-    "name": "Replace All ?'s to Avoid Consecutive Repeating Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1576,
+    "title": "Replace All ?'s to Avoid Consecutive Repeating Characters",
+    "titleSlug": "replace-all-s-to-avoid-consecutive-repeating-characters"
   },
   {
-    "code": "special-positions-in-a-binary-matrix",
-    "problemNumber": 1582,
-    "name": "Special Positions in a Binary Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1582,
+    "title": "Special Positions in a Binary Matrix",
+    "titleSlug": "special-positions-in-a-binary-matrix"
   },
   {
-    "code": "sum-of-all-odd-length-subarrays",
-    "problemNumber": 1588,
-    "name": "Sum of All Odd Length Subarrays",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1588,
+    "title": "Sum of All Odd Length Subarrays",
+    "titleSlug": "sum-of-all-odd-length-subarrays"
   },
   {
-    "code": "rearrange-spaces-between-words",
-    "problemNumber": 1592,
-    "name": "Rearrange Spaces Between Words",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1592,
+    "title": "Rearrange Spaces Between Words",
+    "titleSlug": "rearrange-spaces-between-words"
   },
   {
-    "code": "crawler-log-folder",
-    "problemNumber": 1598,
-    "name": "Crawler Log Folder",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1598,
+    "title": "Crawler Log Folder",
+    "titleSlug": "crawler-log-folder"
   },
   {
-    "code": "design-parking-system",
-    "problemNumber": 1603,
-    "name": "Design Parking System",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1603,
+    "title": "Design Parking System",
+    "titleSlug": "design-parking-system"
   },
   {
-    "code": "special-array-with-x-elements-greater-than-or-equal-x",
-    "problemNumber": 1608,
-    "name": "Special Array With X Elements Greater Than or Equal X",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1608,
+    "title": "Special Array With X Elements Greater Than or Equal X",
+    "titleSlug": "special-array-with-x-elements-greater-than-or-equal-x"
   },
   {
-    "code": "maximum-nesting-depth-of-the-parentheses",
-    "problemNumber": 1614,
-    "name": "Maximum Nesting Depth of the Parentheses",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1614,
+    "title": "Maximum Nesting Depth of the Parentheses",
+    "titleSlug": "maximum-nesting-depth-of-the-parentheses"
   },
   {
-    "code": "mean-of-array-after-removing-some-elements",
-    "problemNumber": 1619,
-    "name": "Mean of Array After Removing Some Elements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1619,
+    "title": "Mean of Array After Removing Some Elements",
+    "titleSlug": "mean-of-array-after-removing-some-elements"
   },
   {
-    "code": "largest-substring-between-two-equal-characters",
-    "problemNumber": 1624,
-    "name": "Largest Substring Between Two Equal Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1624,
+    "title": "Largest Substring Between Two Equal Characters",
+    "titleSlug": "largest-substring-between-two-equal-characters"
   },
   {
-    "code": "slowest-key",
-    "problemNumber": 1629,
-    "name": "Slowest Key",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1629,
+    "title": "Slowest Key",
+    "titleSlug": "slowest-key"
   },
   {
-    "code": "sort-array-by-increasing-frequency",
-    "problemNumber": 1636,
-    "name": "Sort Array by Increasing Frequency",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1636,
+    "title": "Sort Array by Increasing Frequency",
+    "titleSlug": "sort-array-by-increasing-frequency"
   },
   {
-    "code": "widest-vertical-area-between-two-points-containing-no-points",
-    "problemNumber": 1637,
-    "name": "Widest Vertical Area Between Two Points Containing No Points",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1637,
+    "title": "Widest Vertical Area Between Two Points Containing No Points",
+    "titleSlug": "widest-vertical-area-between-two-points-containing-no-points"
   },
   {
-    "code": "check-array-formation-through-concatenation",
-    "problemNumber": 1640,
-    "name": "Check Array Formation Through Concatenation",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1640,
+    "title": "Check Array Formation Through Concatenation",
+    "titleSlug": "check-array-formation-through-concatenation"
   },
   {
-    "code": "get-maximum-in-generated-array",
-    "problemNumber": 1646,
-    "name": "Get Maximum in Generated Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1646,
+    "title": "Get Maximum in Generated Array",
+    "titleSlug": "get-maximum-in-generated-array"
   },
   {
-    "code": "defuse-the-bomb",
-    "problemNumber": 1652,
-    "name": "Defuse the Bomb",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1652,
+    "title": "Defuse the Bomb",
+    "titleSlug": "defuse-the-bomb"
   },
   {
-    "code": "design-an-ordered-stream",
-    "problemNumber": 1656,
-    "name": "Design an Ordered Stream",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1656,
+    "title": "Design an Ordered Stream",
+    "titleSlug": "design-an-ordered-stream"
   },
   {
-    "code": "check-if-two-string-arrays-are-equivalent",
-    "problemNumber": 1662,
-    "name": "Check If Two String Arrays are Equivalent",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1662,
+    "title": "Check If Two String Arrays are Equivalent",
+    "titleSlug": "check-if-two-string-arrays-are-equivalent"
   },
   {
-    "code": "maximum-repeating-substring",
-    "problemNumber": 1668,
-    "name": "Maximum Repeating Substring",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1668,
+    "title": "Maximum Repeating Substring",
+    "titleSlug": "maximum-repeating-substring"
   },
   {
-    "code": "richest-customer-wealth",
-    "problemNumber": 1672,
-    "name": "Richest Customer Wealth",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1672,
+    "title": "Richest Customer Wealth",
+    "titleSlug": "richest-customer-wealth"
   },
   {
-    "code": "goal-parser-interpretation",
-    "problemNumber": 1678,
-    "name": "Goal Parser Interpretation",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1678,
+    "title": "Goal Parser Interpretation",
+    "titleSlug": "goal-parser-interpretation"
   },
   {
-    "code": "count-the-number-of-consistent-strings",
-    "problemNumber": 1684,
-    "name": "Count the Number of Consistent Strings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1684,
+    "title": "Count the Number of Consistent Strings",
+    "titleSlug": "count-the-number-of-consistent-strings"
   },
   {
-    "code": "count-of-matches-in-tournament",
-    "problemNumber": 1688,
-    "name": "Count of Matches in Tournament",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1688,
+    "title": "Count of Matches in Tournament",
+    "titleSlug": "count-of-matches-in-tournament"
   },
   {
-    "code": "reformat-phone-number",
-    "problemNumber": 1694,
-    "name": "Reformat Phone Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1694,
+    "title": "Reformat Phone Number",
+    "titleSlug": "reformat-phone-number"
   },
   {
-    "code": "number-of-students-unable-to-eat-lunch",
-    "problemNumber": 1700,
-    "name": "Number of Students Unable to Eat Lunch",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1700,
+    "title": "Number of Students Unable to Eat Lunch",
+    "titleSlug": "number-of-students-unable-to-eat-lunch"
   },
   {
-    "code": "determine-if-string-halves-are-alike",
-    "problemNumber": 1704,
-    "name": "Determine if String Halves Are Alike",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1704,
+    "title": "Determine if String Halves Are Alike",
+    "titleSlug": "determine-if-string-halves-are-alike"
   },
   {
-    "code": "largest-subarray-length-k",
-    "problemNumber": 1708,
-    "name": "Largest Subarray Length K",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1708,
+    "title": "Largest Subarray Length K",
+    "titleSlug": "largest-subarray-length-k"
   },
   {
-    "code": "maximum-units-on-a-truck",
-    "problemNumber": 1710,
-    "name": "Maximum Units on a Truck",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1710,
+    "title": "Maximum Units on a Truck",
+    "titleSlug": "maximum-units-on-a-truck"
   },
   {
-    "code": "calculate-money-in-leetcode-bank",
-    "problemNumber": 1716,
-    "name": "Calculate Money in Leetcode Bank",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1716,
+    "title": "Calculate Money in Leetcode Bank",
+    "titleSlug": "calculate-money-in-leetcode-bank"
   },
   {
-    "code": "decode-xored-array",
-    "problemNumber": 1720,
-    "name": "Decode XORed Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1720,
+    "title": "Decode XORed Array",
+    "titleSlug": "decode-xored-array"
   },
   {
-    "code": "number-of-rectangles-that-can-form-the-largest-square",
-    "problemNumber": 1725,
-    "name": "Number Of Rectangles That Can Form The Largest Square",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1725,
+    "title": "Number Of Rectangles That Can Form The Largest Square",
+    "titleSlug": "number-of-rectangles-that-can-form-the-largest-square"
   },
   {
-    "code": "find-the-highest-altitude",
-    "problemNumber": 1732,
-    "name": "Find the Highest Altitude",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1732,
+    "title": "Find the Highest Altitude",
+    "titleSlug": "find-the-highest-altitude"
   },
   {
-    "code": "latest-time-by-replacing-hidden-digits",
-    "problemNumber": 1736,
-    "name": "Latest Time by Replacing Hidden Digits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1736,
+    "title": "Latest Time by Replacing Hidden Digits",
+    "titleSlug": "latest-time-by-replacing-hidden-digits"
   },
   {
-    "code": "maximum-number-of-balls-in-a-box",
-    "problemNumber": 1742,
-    "name": "Maximum Number of Balls in a Box",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1742,
+    "title": "Maximum Number of Balls in a Box",
+    "titleSlug": "maximum-number-of-balls-in-a-box"
   },
   {
-    "code": "sum-of-unique-elements",
-    "problemNumber": 1748,
-    "name": "Sum of Unique Elements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1748,
+    "title": "Sum of Unique Elements",
+    "titleSlug": "sum-of-unique-elements"
   },
   {
-    "code": "check-if-array-is-sorted-and-rotated",
-    "problemNumber": 1752,
-    "name": "Check if Array Is Sorted and Rotated",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1752,
+    "title": "Check if Array Is Sorted and Rotated",
+    "titleSlug": "check-if-array-is-sorted-and-rotated"
   },
   {
-    "code": "minimum-changes-to-make-alternating-binary-string",
-    "problemNumber": 1758,
-    "name": "Minimum Changes To Make Alternating Binary String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1758,
+    "title": "Minimum Changes To Make Alternating Binary String",
+    "titleSlug": "minimum-changes-to-make-alternating-binary-string"
   },
   {
-    "code": "longest-nice-substring",
-    "problemNumber": 1763,
-    "name": "Longest Nice Substring",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1763,
+    "title": "Longest Nice Substring",
+    "titleSlug": "longest-nice-substring"
   },
   {
-    "code": "merge-strings-alternately",
-    "problemNumber": 1768,
-    "name": "Merge Strings Alternately",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1768,
+    "title": "Merge Strings Alternately",
+    "titleSlug": "merge-strings-alternately"
   },
   {
-    "code": "count-items-matching-a-rule",
-    "problemNumber": 1773,
-    "name": "Count Items Matching a Rule",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1773,
+    "title": "Count Items Matching a Rule",
+    "titleSlug": "count-items-matching-a-rule"
   },
   {
-    "code": "find-nearest-point-that-has-the-same-x-or-y-coordinate",
-    "problemNumber": 1779,
-    "name": "Find Nearest Point That Has the Same X or Y Coordinate",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1779,
+    "title": "Find Nearest Point That Has the Same X or Y Coordinate",
+    "titleSlug": "find-nearest-point-that-has-the-same-x-or-y-coordinate"
   },
   {
-    "code": "check-if-binary-string-has-at-most-one-segment-of-ones",
-    "problemNumber": 1784,
-    "name": "Check if Binary String Has at Most One Segment of Ones",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1784,
+    "title": "Check if Binary String Has at Most One Segment of Ones",
+    "titleSlug": "check-if-binary-string-has-at-most-one-segment-of-ones"
   },
   {
-    "code": "check-if-one-string-swap-can-make-strings-equal",
-    "problemNumber": 1790,
-    "name": "Check if One String Swap Can Make Strings Equal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1790,
+    "title": "Check if One String Swap Can Make Strings Equal",
+    "titleSlug": "check-if-one-string-swap-can-make-strings-equal"
   },
   {
-    "code": "find-center-of-star-graph",
-    "problemNumber": 1791,
-    "name": "Find Center of Star Graph",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1791,
+    "title": "Find Center of Star Graph",
+    "titleSlug": "find-center-of-star-graph"
   },
   {
-    "code": "second-largest-digit-in-a-string",
-    "problemNumber": 1796,
-    "name": "Second Largest Digit in a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1796,
+    "title": "Second Largest Digit in a String",
+    "titleSlug": "second-largest-digit-in-a-string"
   },
   {
-    "code": "maximum-ascending-subarray-sum",
-    "problemNumber": 1800,
-    "name": "Maximum Ascending Subarray Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1800,
+    "title": "Maximum Ascending Subarray Sum",
+    "titleSlug": "maximum-ascending-subarray-sum"
   },
   {
-    "code": "number-of-different-integers-in-a-string",
-    "problemNumber": 1805,
-    "name": "Number of Different Integers in a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1805,
+    "title": "Number of Different Integers in a String",
+    "titleSlug": "number-of-different-integers-in-a-string"
   },
   {
-    "code": "determine-color-of-a-chessboard-square",
-    "problemNumber": 1812,
-    "name": "Determine Color of a Chessboard Square",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1812,
+    "title": "Determine Color of a Chessboard Square",
+    "titleSlug": "determine-color-of-a-chessboard-square"
   },
   {
-    "code": "truncate-sentence",
-    "problemNumber": 1816,
-    "name": "Truncate Sentence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1816,
+    "title": "Truncate Sentence",
+    "titleSlug": "truncate-sentence"
   },
   {
-    "code": "sign-of-the-product-of-an-array",
-    "problemNumber": 1822,
-    "name": "Sign of the Product of an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1822,
+    "title": "Sign of the Product of an Array",
+    "titleSlug": "sign-of-the-product-of-an-array"
   },
   {
-    "code": "faulty-sensor",
-    "problemNumber": 1826,
-    "name": "Faulty Sensor",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1826,
+    "title": "Faulty Sensor",
+    "titleSlug": "faulty-sensor"
   },
   {
-    "code": "minimum-operations-to-make-the-array-increasing",
-    "problemNumber": 1827,
-    "name": "Minimum Operations to Make the Array Increasing",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1827,
+    "title": "Minimum Operations to Make the Array Increasing",
+    "titleSlug": "minimum-operations-to-make-the-array-increasing"
   },
   {
-    "code": "check-if-the-sentence-is-pangram",
-    "problemNumber": 1832,
-    "name": "Check if the Sentence Is Pangram",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1832,
+    "title": "Check if the Sentence Is Pangram",
+    "titleSlug": "check-if-the-sentence-is-pangram"
   },
   {
-    "code": "sum-of-digits-in-base-k",
-    "problemNumber": 1837,
-    "name": "Sum of Digits in Base K",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1837,
+    "title": "Sum of Digits in Base K",
+    "titleSlug": "sum-of-digits-in-base-k"
   },
   {
-    "code": "replace-all-digits-with-characters",
-    "problemNumber": 1844,
-    "name": "Replace All Digits with Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1844,
+    "title": "Replace All Digits with Characters",
+    "titleSlug": "replace-all-digits-with-characters"
   },
   {
-    "code": "minimum-distance-to-the-target-element",
-    "problemNumber": 1848,
-    "name": "Minimum Distance to the Target Element",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1848,
+    "title": "Minimum Distance to the Target Element",
+    "titleSlug": "minimum-distance-to-the-target-element"
   },
   {
-    "code": "maximum-population-year",
-    "problemNumber": 1854,
-    "name": "Maximum Population Year",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1854,
+    "title": "Maximum Population Year",
+    "titleSlug": "maximum-population-year"
   },
   {
-    "code": "sorting-the-sentence",
-    "problemNumber": 1859,
-    "name": "Sorting the Sentence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1859,
+    "title": "Sorting the Sentence",
+    "titleSlug": "sorting-the-sentence"
   },
   {
-    "code": "sum-of-all-subset-xor-totals",
-    "problemNumber": 1863,
-    "name": "Sum of All Subset XOR Totals",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1863,
+    "title": "Sum of All Subset XOR Totals",
+    "titleSlug": "sum-of-all-subset-xor-totals"
   },
   {
-    "code": "longer-contiguous-segments-of-ones-than-zeros",
-    "problemNumber": 1869,
-    "name": "Longer Contiguous Segments of Ones than Zeros",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1869,
+    "title": "Longer Contiguous Segments of Ones than Zeros",
+    "titleSlug": "longer-contiguous-segments-of-ones-than-zeros"
   },
   {
-    "code": "substrings-of-size-three-with-distinct-characters",
-    "problemNumber": 1876,
-    "name": "Substrings of Size Three with Distinct Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1876,
+    "title": "Substrings of Size Three with Distinct Characters",
+    "titleSlug": "substrings-of-size-three-with-distinct-characters"
   },
   {
-    "code": "check-if-word-equals-summation-of-two-words",
-    "problemNumber": 1880,
-    "name": "Check if Word Equals Summation of Two Words",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1880,
+    "title": "Check if Word Equals Summation of Two Words",
+    "titleSlug": "check-if-word-equals-summation-of-two-words"
   },
   {
-    "code": "determine-whether-matrix-can-be-obtained-by-rotation",
-    "problemNumber": 1886,
-    "name": "Determine Whether Matrix Can Be Obtained By Rotation",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1886,
+    "title": "Determine Whether Matrix Can Be Obtained By Rotation",
+    "titleSlug": "determine-whether-matrix-can-be-obtained-by-rotation"
   },
   {
-    "code": "check-if-all-the-integers-in-a-range-are-covered",
-    "problemNumber": 1893,
-    "name": "Check if All the Integers in a Range Are Covered",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1893,
+    "title": "Check if All the Integers in a Range Are Covered",
+    "titleSlug": "check-if-all-the-integers-in-a-range-are-covered"
   },
   {
-    "code": "redistribute-characters-to-make-all-strings-equal",
-    "problemNumber": 1897,
-    "name": "Redistribute Characters to Make All Strings Equal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1897,
+    "title": "Redistribute Characters to Make All Strings Equal",
+    "titleSlug": "redistribute-characters-to-make-all-strings-equal"
   },
   {
-    "code": "largest-odd-number-in-string",
-    "problemNumber": 1903,
-    "name": "Largest Odd Number in String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1903,
+    "title": "Largest Odd Number in String",
+    "titleSlug": "largest-odd-number-in-string"
   },
   {
-    "code": "remove-one-element-to-make-the-array-strictly-increasing",
-    "problemNumber": 1909,
-    "name": "Remove One Element to Make the Array Strictly Increasing",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1909,
+    "title": "Remove One Element to Make the Array Strictly Increasing",
+    "titleSlug": "remove-one-element-to-make-the-array-strictly-increasing"
   },
   {
-    "code": "maximum-product-difference-between-two-pairs",
-    "problemNumber": 1913,
-    "name": "Maximum Product Difference Between Two Pairs",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1913,
+    "title": "Maximum Product Difference Between Two Pairs",
+    "titleSlug": "maximum-product-difference-between-two-pairs"
   },
   {
-    "code": "build-array-from-permutation",
-    "problemNumber": 1920,
-    "name": "Build Array from Permutation",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1920,
+    "title": "Build Array from Permutation",
+    "titleSlug": "build-array-from-permutation"
   },
   {
-    "code": "count-square-sum-triples",
-    "problemNumber": 1925,
-    "name": "Count Square Sum Triples",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1925,
+    "title": "Count Square Sum Triples",
+    "titleSlug": "count-square-sum-triples"
   },
   {
-    "code": "concatenation-of-array",
-    "problemNumber": 1929,
-    "name": "Concatenation of Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1929,
+    "title": "Concatenation of Array",
+    "titleSlug": "concatenation-of-array"
   },
   {
-    "code": "check-if-string-is-decomposable-into-value-equal-substrings",
-    "problemNumber": 1933,
-    "name": "Check if String Is Decomposable Into Value-Equal Substrings",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 1933,
+    "title": "Check if String Is Decomposable Into Value-Equal Substrings",
+    "titleSlug": "check-if-string-is-decomposable-into-value-equal-substrings"
   },
   {
-    "code": "maximum-number-of-words-you-can-type",
-    "problemNumber": 1935,
-    "name": "Maximum Number of Words You Can Type",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1935,
+    "title": "Maximum Number of Words You Can Type",
+    "titleSlug": "maximum-number-of-words-you-can-type"
   },
   {
-    "code": "check-if-all-characters-have-equal-number-of-occurrences",
-    "problemNumber": 1941,
-    "name": "Check if All Characters Have Equal Number of Occurrences",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1941,
+    "title": "Check if All Characters Have Equal Number of Occurrences",
+    "titleSlug": "check-if-all-characters-have-equal-number-of-occurrences"
   },
   {
-    "code": "sum-of-digits-of-string-after-convert",
-    "problemNumber": 1945,
-    "name": "Sum of Digits of String After Convert",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1945,
+    "title": "Sum of Digits of String After Convert",
+    "titleSlug": "sum-of-digits-of-string-after-convert"
   },
   {
-    "code": "three-divisors",
-    "problemNumber": 1952,
-    "name": "Three Divisors",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1952,
+    "title": "Three Divisors",
+    "titleSlug": "three-divisors"
   },
   {
-    "code": "delete-characters-to-make-fancy-string",
-    "problemNumber": 1957,
-    "name": "Delete Characters to Make Fancy String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1957,
+    "title": "Delete Characters to Make Fancy String",
+    "titleSlug": "delete-characters-to-make-fancy-string"
   },
   {
-    "code": "check-if-string-is-a-prefix-of-array",
-    "problemNumber": 1961,
-    "name": "Check If String Is a Prefix of Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1961,
+    "title": "Check If String Is a Prefix of Array",
+    "titleSlug": "check-if-string-is-a-prefix-of-array"
   },
   {
-    "code": "number-of-strings-that-appear-as-substrings-in-word",
-    "problemNumber": 1967,
-    "name": "Number of Strings That Appear as Substrings in Word",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1967,
+    "title": "Number of Strings That Appear as Substrings in Word",
+    "titleSlug": "number-of-strings-that-appear-as-substrings-in-word"
   },
   {
-    "code": "find-if-path-exists-in-graph",
-    "problemNumber": 1971,
-    "name": "Find if Path Exists in Graph",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1971,
+    "title": "Find if Path Exists in Graph",
+    "titleSlug": "find-if-path-exists-in-graph"
   },
   {
-    "code": "minimum-time-to-type-word-using-special-typewriter",
-    "problemNumber": 1974,
-    "name": "Minimum Time to Type Word Using Special Typewriter",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1974,
+    "title": "Minimum Time to Type Word Using Special Typewriter",
+    "titleSlug": "minimum-time-to-type-word-using-special-typewriter"
   },
   {
-    "code": "find-greatest-common-divisor-of-array",
-    "problemNumber": 1979,
-    "name": "Find Greatest Common Divisor of Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1979,
+    "title": "Find Greatest Common Divisor of Array",
+    "titleSlug": "find-greatest-common-divisor-of-array"
   },
   {
-    "code": "minimum-difference-between-highest-and-lowest-of-k-scores",
-    "problemNumber": 1984,
-    "name": "Minimum Difference Between Highest and Lowest of K Scores",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1984,
+    "title": "Minimum Difference Between Highest and Lowest of K Scores",
+    "titleSlug": "minimum-difference-between-highest-and-lowest-of-k-scores"
   },
   {
-    "code": "find-the-middle-index-in-array",
-    "problemNumber": 1991,
-    "name": "Find the Middle Index in Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1991,
+    "title": "Find the Middle Index in Array",
+    "titleSlug": "find-the-middle-index-in-array"
   },
   {
-    "code": "count-special-quadruplets",
-    "problemNumber": 1995,
-    "name": "Count Special Quadruplets",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 1995,
+    "title": "Count Special Quadruplets",
+    "titleSlug": "count-special-quadruplets"
   },
   {
-    "code": "reverse-prefix-of-word",
-    "problemNumber": 2000,
-    "name": "Reverse Prefix of Word",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2000,
+    "title": "Reverse Prefix of Word",
+    "titleSlug": "reverse-prefix-of-word"
   },
   {
-    "code": "count-number-of-pairs-with-absolute-difference-k",
-    "problemNumber": 2006,
-    "name": "Count Number of Pairs With Absolute Difference K",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2006,
+    "title": "Count Number of Pairs With Absolute Difference K",
+    "titleSlug": "count-number-of-pairs-with-absolute-difference-k"
   },
   {
-    "code": "final-value-of-variable-after-performing-operations",
-    "problemNumber": 2011,
-    "name": "Final Value of Variable After Performing Operations",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2011,
+    "title": "Final Value of Variable After Performing Operations",
+    "titleSlug": "final-value-of-variable-after-performing-operations"
   },
   {
-    "code": "maximum-difference-between-increasing-elements",
-    "problemNumber": 2016,
-    "name": "Maximum Difference Between Increasing Elements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2016,
+    "title": "Maximum Difference Between Increasing Elements",
+    "titleSlug": "maximum-difference-between-increasing-elements"
   },
   {
-    "code": "convert-1d-array-into-2d-array",
-    "problemNumber": 2022,
-    "name": "Convert 1D Array Into 2D Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2022,
+    "title": "Convert 1D Array Into 2D Array",
+    "titleSlug": "convert-1d-array-into-2d-array"
   },
   {
-    "code": "minimum-moves-to-convert-string",
-    "problemNumber": 2027,
-    "name": "Minimum Moves to Convert String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2027,
+    "title": "Minimum Moves to Convert String",
+    "titleSlug": "minimum-moves-to-convert-string"
   },
   {
-    "code": "two-out-of-three",
-    "problemNumber": 2032,
-    "name": "Two Out of Three",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2032,
+    "title": "Two Out of Three",
+    "titleSlug": "two-out-of-three"
   },
   {
-    "code": "minimum-number-of-moves-to-seat-everyone",
-    "problemNumber": 2037,
-    "name": "Minimum Number of Moves to Seat Everyone",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2037,
+    "title": "Minimum Number of Moves to Seat Everyone",
+    "titleSlug": "minimum-number-of-moves-to-seat-everyone"
   },
   {
-    "code": "check-if-numbers-are-ascending-in-a-sentence",
-    "problemNumber": 2042,
-    "name": "Check if Numbers Are Ascending in a Sentence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2042,
+    "title": "Check if Numbers Are Ascending in a Sentence",
+    "titleSlug": "check-if-numbers-are-ascending-in-a-sentence"
   },
   {
-    "code": "number-of-valid-words-in-a-sentence",
-    "problemNumber": 2047,
-    "name": "Number of Valid Words in a Sentence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2047,
+    "title": "Number of Valid Words in a Sentence",
+    "titleSlug": "number-of-valid-words-in-a-sentence"
   },
   {
-    "code": "kth-distinct-string-in-an-array",
-    "problemNumber": 2053,
-    "name": "Kth Distinct String in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2053,
+    "title": "Kth Distinct String in an Array",
+    "titleSlug": "kth-distinct-string-in-an-array"
   },
   {
-    "code": "smallest-index-with-equal-value",
-    "problemNumber": 2057,
-    "name": "Smallest Index With Equal Value",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2057,
+    "title": "Smallest Index With Equal Value",
+    "titleSlug": "smallest-index-with-equal-value"
   },
   {
-    "code": "count-vowel-substrings-of-a-string",
-    "problemNumber": 2062,
-    "name": "Count Vowel Substrings of a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2062,
+    "title": "Count Vowel Substrings of a String",
+    "titleSlug": "count-vowel-substrings-of-a-string"
   },
   {
-    "code": "check-whether-two-strings-are-almost-equivalent",
-    "problemNumber": 2068,
-    "name": "Check Whether Two Strings are Almost Equivalent",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2068,
+    "title": "Check Whether Two Strings are Almost Equivalent",
+    "titleSlug": "check-whether-two-strings-are-almost-equivalent"
   },
   {
-    "code": "time-needed-to-buy-tickets",
-    "problemNumber": 2073,
-    "name": "Time Needed to Buy Tickets",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2073,
+    "title": "Time Needed to Buy Tickets",
+    "titleSlug": "time-needed-to-buy-tickets"
   },
   {
-    "code": "two-furthest-houses-with-different-colors",
-    "problemNumber": 2078,
-    "name": "Two Furthest Houses With Different Colors",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2078,
+    "title": "Two Furthest Houses With Different Colors",
+    "titleSlug": "two-furthest-houses-with-different-colors"
   },
   {
-    "code": "count-common-words-with-one-occurrence",
-    "problemNumber": 2085,
-    "name": "Count Common Words With One Occurrence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2085,
+    "title": "Count Common Words With One Occurrence",
+    "titleSlug": "count-common-words-with-one-occurrence"
   },
   {
-    "code": "find-target-indices-after-sorting-array",
-    "problemNumber": 2089,
-    "name": "Find Target Indices After Sorting Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2089,
+    "title": "Find Target Indices After Sorting Array",
+    "titleSlug": "find-target-indices-after-sorting-array"
   },
   {
-    "code": "finding-3-digit-even-numbers",
-    "problemNumber": 2094,
-    "name": "Finding 3-Digit Even Numbers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2094,
+    "title": "Finding 3-Digit Even Numbers",
+    "titleSlug": "finding-3-digit-even-numbers"
   },
   {
-    "code": "find-subsequence-of-length-k-with-the-largest-sum",
-    "problemNumber": 2099,
-    "name": "Find Subsequence of Length K With the Largest Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2099,
+    "title": "Find Subsequence of Length K With the Largest Sum",
+    "titleSlug": "find-subsequence-of-length-k-with-the-largest-sum"
   },
   {
-    "code": "rings-and-rods",
-    "problemNumber": 2103,
-    "name": "Rings and Rods",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2103,
+    "title": "Rings and Rods",
+    "titleSlug": "rings-and-rods"
   },
   {
-    "code": "find-first-palindromic-string-in-the-array",
-    "problemNumber": 2108,
-    "name": "Find First Palindromic String in the Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2108,
+    "title": "Find First Palindromic String in the Array",
+    "titleSlug": "find-first-palindromic-string-in-the-array"
   },
   {
-    "code": "maximum-number-of-words-found-in-sentences",
-    "problemNumber": 2114,
-    "name": "Maximum Number of Words Found in Sentences",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2114,
+    "title": "Maximum Number of Words Found in Sentences",
+    "titleSlug": "maximum-number-of-words-found-in-sentences"
   },
   {
-    "code": "a-number-after-a-double-reversal",
-    "problemNumber": 2119,
-    "name": "A Number After a Double Reversal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2119,
+    "title": "A Number After a Double Reversal",
+    "titleSlug": "a-number-after-a-double-reversal"
   },
   {
-    "code": "check-if-all-as-appears-before-all-bs",
-    "problemNumber": 2124,
-    "name": "Check if All A's Appears Before All B's",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2124,
+    "title": "Check if All A's Appears Before All B's",
+    "titleSlug": "check-if-all-as-appears-before-all-bs"
   },
   {
-    "code": "capitalize-the-title",
-    "problemNumber": 2129,
-    "name": "Capitalize the Title",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2129,
+    "title": "Capitalize the Title",
+    "titleSlug": "capitalize-the-title"
   },
   {
-    "code": "check-if-every-row-and-column-contains-all-numbers",
-    "problemNumber": 2133,
-    "name": "Check if Every Row and Column Contains All Numbers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2133,
+    "title": "Check if Every Row and Column Contains All Numbers",
+    "titleSlug": "check-if-every-row-and-column-contains-all-numbers"
   },
   {
-    "code": "divide-a-string-into-groups-of-size-k",
-    "problemNumber": 2138,
-    "name": "Divide a String Into Groups of Size k",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2138,
+    "title": "Divide a String Into Groups of Size k",
+    "titleSlug": "divide-a-string-into-groups-of-size-k"
   },
   {
-    "code": "minimum-cost-of-buying-candies-with-discount",
-    "problemNumber": 2144,
-    "name": "Minimum Cost of Buying Candies With Discount",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2144,
+    "title": "Minimum Cost of Buying Candies With Discount",
+    "titleSlug": "minimum-cost-of-buying-candies-with-discount"
   },
   {
-    "code": "count-elements-with-strictly-smaller-and-greater-elements",
-    "problemNumber": 2148,
-    "name": "Count Elements With Strictly Smaller and Greater Elements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2148,
+    "title": "Count Elements With Strictly Smaller and Greater Elements",
+    "titleSlug": "count-elements-with-strictly-smaller-and-greater-elements"
   },
   {
-    "code": "keep-multiplying-found-values-by-two",
-    "problemNumber": 2154,
-    "name": "Keep Multiplying Found Values by Two",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2154,
+    "title": "Keep Multiplying Found Values by Two",
+    "titleSlug": "keep-multiplying-found-values-by-two"
   },
   {
-    "code": "minimum-sum-of-four-digit-number-after-splitting-digits",
-    "problemNumber": 2160,
-    "name": "Minimum Sum of Four Digit Number After Splitting Digits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2160,
+    "title": "Minimum Sum of Four Digit Number After Splitting Digits",
+    "titleSlug": "minimum-sum-of-four-digit-number-after-splitting-digits"
   },
   {
-    "code": "sort-even-and-odd-indices-independently",
-    "problemNumber": 2164,
-    "name": "Sort Even and Odd Indices Independently",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2164,
+    "title": "Sort Even and Odd Indices Independently",
+    "titleSlug": "sort-even-and-odd-indices-independently"
   },
   {
-    "code": "count-operations-to-obtain-zero",
-    "problemNumber": 2169,
-    "name": "Count Operations to Obtain Zero",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2169,
+    "title": "Count Operations to Obtain Zero",
+    "titleSlug": "count-operations-to-obtain-zero"
   },
   {
-    "code": "count-equal-and-divisible-pairs-in-an-array",
-    "problemNumber": 2176,
-    "name": "Count Equal and Divisible Pairs in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2176,
+    "title": "Count Equal and Divisible Pairs in an Array",
+    "titleSlug": "count-equal-and-divisible-pairs-in-an-array"
   },
   {
-    "code": "count-integers-with-even-digit-sum",
-    "problemNumber": 2180,
-    "name": "Count Integers With Even Digit Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2180,
+    "title": "Count Integers With Even Digit Sum",
+    "titleSlug": "count-integers-with-even-digit-sum"
   },
   {
-    "code": "counting-words-with-a-given-prefix",
-    "problemNumber": 2185,
-    "name": "Counting Words With a Given Prefix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2185,
+    "title": "Counting Words With a Given Prefix",
+    "titleSlug": "counting-words-with-a-given-prefix"
   },
   {
-    "code": "most-frequent-number-following-key-in-an-array",
-    "problemNumber": 2190,
-    "name": "Most Frequent Number Following Key In an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2190,
+    "title": "Most Frequent Number Following Key In an Array",
+    "titleSlug": "most-frequent-number-following-key-in-an-array"
   },
   {
-    "code": "cells-in-a-range-on-an-excel-sheet",
-    "problemNumber": 2194,
-    "name": "Cells in a Range on an Excel Sheet",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2194,
+    "title": "Cells in a Range on an Excel Sheet",
+    "titleSlug": "cells-in-a-range-on-an-excel-sheet"
   },
   {
-    "code": "find-all-k-distant-indices-in-an-array",
-    "problemNumber": 2200,
-    "name": "Find All K-Distant Indices in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2200,
+    "title": "Find All K-Distant Indices in an Array",
+    "titleSlug": "find-all-k-distant-indices-in-an-array"
   },
   {
-    "code": "divide-array-into-equal-pairs",
-    "problemNumber": 2206,
-    "name": "Divide Array Into Equal Pairs",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2206,
+    "title": "Divide Array Into Equal Pairs",
+    "titleSlug": "divide-array-into-equal-pairs"
   },
   {
-    "code": "count-hills-and-valleys-in-an-array",
-    "problemNumber": 2210,
-    "name": "Count Hills and Valleys in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2210,
+    "title": "Count Hills and Valleys in an Array",
+    "titleSlug": "count-hills-and-valleys-in-an-array"
   },
   {
-    "code": "find-the-difference-of-two-arrays",
-    "problemNumber": 2215,
-    "name": "Find the Difference of Two Arrays",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2215,
+    "title": "Find the Difference of Two Arrays",
+    "titleSlug": "find-the-difference-of-two-arrays"
   },
   {
-    "code": "minimum-bit-flips-to-convert-number",
-    "problemNumber": 2220,
-    "name": "Minimum Bit Flips to Convert Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2220,
+    "title": "Minimum Bit Flips to Convert Number",
+    "titleSlug": "minimum-bit-flips-to-convert-number"
   },
   {
-    "code": "minimum-number-of-operations-to-convert-time",
-    "problemNumber": 2224,
-    "name": "Minimum Number of Operations to Convert Time",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2224,
+    "title": "Minimum Number of Operations to Convert Time",
+    "titleSlug": "minimum-number-of-operations-to-convert-time"
   },
   {
-    "code": "check-if-an-array-is-consecutive",
-    "problemNumber": 2229,
-    "name": "Check if an Array Is Consecutive",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 2229,
+    "title": "Check if an Array Is Consecutive",
+    "titleSlug": "check-if-an-array-is-consecutive"
   },
   {
-    "code": "largest-number-after-digit-swaps-by-parity",
-    "problemNumber": 2231,
-    "name": "Largest Number After Digit Swaps by Parity",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2231,
+    "title": "Largest Number After Digit Swaps by Parity",
+    "titleSlug": "largest-number-after-digit-swaps-by-parity"
   },
   {
-    "code": "add-two-integers",
-    "problemNumber": 2235,
-    "name": "Add Two Integers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2235,
+    "title": "Add Two Integers",
+    "titleSlug": "add-two-integers"
   },
   {
-    "code": "root-equals-sum-of-children",
-    "problemNumber": 2236,
-    "name": "Root Equals Sum of Children",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2236,
+    "title": "Root Equals Sum of Children",
+    "titleSlug": "root-equals-sum-of-children"
   },
   {
-    "code": "find-closest-number-to-zero",
-    "problemNumber": 2239,
-    "name": "Find Closest Number to Zero",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2239,
+    "title": "Find Closest Number to Zero",
+    "titleSlug": "find-closest-number-to-zero"
   },
   {
-    "code": "calculate-digit-sum-of-a-string",
-    "problemNumber": 2243,
-    "name": "Calculate Digit Sum of a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2243,
+    "title": "Calculate Digit Sum of a String",
+    "titleSlug": "calculate-digit-sum-of-a-string"
   },
   {
-    "code": "intersection-of-multiple-arrays",
-    "problemNumber": 2248,
-    "name": "Intersection of Multiple Arrays",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2248,
+    "title": "Intersection of Multiple Arrays",
+    "titleSlug": "intersection-of-multiple-arrays"
   },
   {
-    "code": "count-prefixes-of-a-given-string",
-    "problemNumber": 2255,
-    "name": "Count Prefixes of a Given String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2255,
+    "title": "Count Prefixes of a Given String",
+    "titleSlug": "count-prefixes-of-a-given-string"
   },
   {
-    "code": "remove-digit-from-number-to-maximize-result",
-    "problemNumber": 2259,
-    "name": "Remove Digit From Number to Maximize Result",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2259,
+    "title": "Remove Digit From Number to Maximize Result",
+    "titleSlug": "remove-digit-from-number-to-maximize-result"
   },
   {
-    "code": "largest-3-same-digit-number-in-string",
-    "problemNumber": 2264,
-    "name": "Largest 3-Same-Digit Number in String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2264,
+    "title": "Largest 3-Same-Digit Number in String",
+    "titleSlug": "largest-3-same-digit-number-in-string"
   },
   {
-    "code": "find-the-k-beauty-of-a-number",
-    "problemNumber": 2269,
-    "name": "Find the K-Beauty of a Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2269,
+    "title": "Find the K-Beauty of a Number",
+    "titleSlug": "find-the-k-beauty-of-a-number"
   },
   {
-    "code": "find-resultant-array-after-removing-anagrams",
-    "problemNumber": 2273,
-    "name": "Find Resultant Array After Removing Anagrams",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2273,
+    "title": "Find Resultant Array After Removing Anagrams",
+    "titleSlug": "find-resultant-array-after-removing-anagrams"
   },
   {
-    "code": "percentage-of-letter-in-string",
-    "problemNumber": 2278,
-    "name": "Percentage of Letter in String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2278,
+    "title": "Percentage of Letter in String",
+    "titleSlug": "percentage-of-letter-in-string"
   },
   {
-    "code": "check-if-number-has-equal-digit-count-and-digit-value",
-    "problemNumber": 2283,
-    "name": "Check if Number Has Equal Digit Count and Digit Value",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2283,
+    "title": "Check if Number Has Equal Digit Count and Digit Value",
+    "titleSlug": "check-if-number-has-equal-digit-count-and-digit-value"
   },
   {
-    "code": "rearrange-characters-to-make-target-string",
-    "problemNumber": 2287,
-    "name": "Rearrange Characters to Make Target String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2287,
+    "title": "Rearrange Characters to Make Target String",
+    "titleSlug": "rearrange-characters-to-make-target-string"
   },
   {
-    "code": "min-max-game",
-    "problemNumber": 2293,
-    "name": "Min Max Game",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2293,
+    "title": "Min Max Game",
+    "titleSlug": "min-max-game"
   },
   {
-    "code": "strong-password-checker-ii",
-    "problemNumber": 2299,
-    "name": "Strong Password Checker II",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2299,
+    "title": "Strong Password Checker II",
+    "titleSlug": "strong-password-checker-ii"
   },
   {
-    "code": "calculate-amount-paid-in-taxes",
-    "problemNumber": 2303,
-    "name": "Calculate Amount Paid in Taxes",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2303,
+    "title": "Calculate Amount Paid in Taxes",
+    "titleSlug": "calculate-amount-paid-in-taxes"
   },
   {
-    "code": "greatest-english-letter-in-upper-and-lower-case",
-    "problemNumber": 2309,
-    "name": "Greatest English Letter in Upper and Lower Case",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2309,
+    "title": "Greatest English Letter in Upper and Lower Case",
+    "titleSlug": "greatest-english-letter-in-upper-and-lower-case"
   },
   {
-    "code": "count-asterisks",
-    "problemNumber": 2315,
-    "name": "Count Asterisks",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2315,
+    "title": "Count Asterisks",
+    "titleSlug": "count-asterisks"
   },
   {
-    "code": "check-if-matrix-is-x-matrix",
-    "problemNumber": 2319,
-    "name": "Check if Matrix Is X-Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2319,
+    "title": "Check if Matrix Is X-Matrix",
+    "titleSlug": "check-if-matrix-is-x-matrix"
   },
   {
-    "code": "decode-the-message",
-    "problemNumber": 2325,
-    "name": "Decode the Message",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2325,
+    "title": "Decode the Message",
+    "titleSlug": "decode-the-message"
   },
   {
-    "code": "evaluate-boolean-binary-tree",
-    "problemNumber": 2331,
-    "name": "Evaluate Boolean Binary Tree",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2331,
+    "title": "Evaluate Boolean Binary Tree",
+    "titleSlug": "evaluate-boolean-binary-tree"
   },
   {
-    "code": "minimum-amount-of-time-to-fill-cups",
-    "problemNumber": 2335,
-    "name": "Minimum Amount of Time to Fill Cups",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2335,
+    "title": "Minimum Amount of Time to Fill Cups",
+    "titleSlug": "minimum-amount-of-time-to-fill-cups"
   },
   {
-    "code": "maximum-number-of-pairs-in-array",
-    "problemNumber": 2341,
-    "name": "Maximum Number of Pairs in Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2341,
+    "title": "Maximum Number of Pairs in Array",
+    "titleSlug": "maximum-number-of-pairs-in-array"
   },
   {
-    "code": "best-poker-hand",
-    "problemNumber": 2347,
-    "name": "Best Poker Hand",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2347,
+    "title": "Best Poker Hand",
+    "titleSlug": "best-poker-hand"
   },
   {
-    "code": "first-letter-to-appear-twice",
-    "problemNumber": 2351,
-    "name": "First Letter to Appear Twice",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2351,
+    "title": "First Letter to Appear Twice",
+    "titleSlug": "first-letter-to-appear-twice"
   },
   {
-    "code": "make-array-zero-by-subtracting-equal-amounts",
-    "problemNumber": 2357,
-    "name": "Make Array Zero by Subtracting Equal Amounts",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2357,
+    "title": "Make Array Zero by Subtracting Equal Amounts",
+    "titleSlug": "make-array-zero-by-subtracting-equal-amounts"
   },
   {
-    "code": "merge-similar-items",
-    "problemNumber": 2363,
-    "name": "Merge Similar Items",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2363,
+    "title": "Merge Similar Items",
+    "titleSlug": "merge-similar-items"
   },
   {
-    "code": "number-of-arithmetic-triplets",
-    "problemNumber": 2367,
-    "name": "Number of Arithmetic Triplets",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2367,
+    "title": "Number of Arithmetic Triplets",
+    "titleSlug": "number-of-arithmetic-triplets"
   },
   {
-    "code": "largest-local-values-in-a-matrix",
-    "problemNumber": 2373,
-    "name": "Largest Local Values in a Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2373,
+    "title": "Largest Local Values in a Matrix",
+    "titleSlug": "largest-local-values-in-a-matrix"
   },
   {
-    "code": "minimum-recolors-to-get-k-consecutive-black-blocks",
-    "problemNumber": 2379,
-    "name": "Minimum Recolors to Get K Consecutive Black Blocks",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2379,
+    "title": "Minimum Recolors to Get K Consecutive Black Blocks",
+    "titleSlug": "minimum-recolors-to-get-k-consecutive-black-blocks"
   },
   {
-    "code": "minimum-hours-of-training-to-win-a-competition",
-    "problemNumber": 2383,
-    "name": "Minimum Hours of Training to Win a Competition",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2383,
+    "title": "Minimum Hours of Training to Win a Competition",
+    "titleSlug": "minimum-hours-of-training-to-win-a-competition"
   },
   {
-    "code": "longest-subsequence-with-limited-sum",
-    "problemNumber": 2389,
-    "name": "Longest Subsequence With Limited Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2389,
+    "title": "Longest Subsequence With Limited Sum",
+    "titleSlug": "longest-subsequence-with-limited-sum"
   },
   {
-    "code": "find-subarrays-with-equal-sum",
-    "problemNumber": 2395,
-    "name": "Find Subarrays With Equal Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2395,
+    "title": "Find Subarrays With Equal Sum",
+    "titleSlug": "find-subarrays-with-equal-sum"
   },
   {
-    "code": "check-distances-between-same-letters",
-    "problemNumber": 2399,
-    "name": "Check Distances Between Same Letters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2399,
+    "title": "Check Distances Between Same Letters",
+    "titleSlug": "check-distances-between-same-letters"
   },
   {
-    "code": "most-frequent-even-element",
-    "problemNumber": 2404,
-    "name": "Most Frequent Even Element",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2404,
+    "title": "Most Frequent Even Element",
+    "titleSlug": "most-frequent-even-element"
   },
   {
-    "code": "count-days-spent-together",
-    "problemNumber": 2409,
-    "name": "Count Days Spent Together",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2409,
+    "title": "Count Days Spent Together",
+    "titleSlug": "count-days-spent-together"
   },
   {
-    "code": "smallest-even-multiple",
-    "problemNumber": 2413,
-    "name": "Smallest Even Multiple",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2413,
+    "title": "Smallest Even Multiple",
+    "titleSlug": "smallest-even-multiple"
   },
   {
-    "code": "sort-the-people",
-    "problemNumber": 2418,
-    "name": "Sort the People",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2418,
+    "title": "Sort the People",
+    "titleSlug": "sort-the-people"
   },
   {
-    "code": "remove-letter-to-equalize-frequency",
-    "problemNumber": 2423,
-    "name": "Remove Letter To Equalize Frequency",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2423,
+    "title": "Remove Letter To Equalize Frequency",
+    "titleSlug": "remove-letter-to-equalize-frequency"
   },
   {
-    "code": "number-of-common-factors",
-    "problemNumber": 2427,
-    "name": "Number of Common Factors",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2427,
+    "title": "Number of Common Factors",
+    "titleSlug": "number-of-common-factors"
   },
   {
-    "code": "the-employee-that-worked-on-the-longest-task",
-    "problemNumber": 2432,
-    "name": "The Employee That Worked on the Longest Task",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2432,
+    "title": "The Employee That Worked on the Longest Task",
+    "titleSlug": "the-employee-that-worked-on-the-longest-task"
   },
   {
-    "code": "number-of-valid-clock-times",
-    "problemNumber": 2437,
-    "name": "Number of Valid Clock Times",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2437,
+    "title": "Number of Valid Clock Times",
+    "titleSlug": "number-of-valid-clock-times"
   },
   {
-    "code": "largest-positive-integer-that-exists-with-its-negative",
-    "problemNumber": 2441,
-    "name": "Largest Positive Integer That Exists With Its Negative",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2441,
+    "title": "Largest Positive Integer That Exists With Its Negative",
+    "titleSlug": "largest-positive-integer-that-exists-with-its-negative"
   },
   {
-    "code": "determine-if-two-events-have-conflict",
-    "problemNumber": 2446,
-    "name": "Determine if Two Events Have Conflict",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2446,
+    "title": "Determine if Two Events Have Conflict",
+    "titleSlug": "determine-if-two-events-have-conflict"
   },
   {
-    "code": "odd-string-difference",
-    "problemNumber": 2451,
-    "name": "Odd String Difference",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2451,
+    "title": "Odd String Difference",
+    "titleSlug": "odd-string-difference"
   },
   {
-    "code": "average-value-of-even-numbers-that-are-divisible-by-three",
-    "problemNumber": 2455,
-    "name": "Average Value of Even Numbers That Are Divisible by Three",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2455,
+    "title": "Average Value of Even Numbers That Are Divisible by Three",
+    "titleSlug": "average-value-of-even-numbers-that-are-divisible-by-three"
   },
   {
-    "code": "apply-operations-to-an-array",
-    "problemNumber": 2460,
-    "name": "Apply Operations to an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2460,
+    "title": "Apply Operations to an Array",
+    "titleSlug": "apply-operations-to-an-array"
   },
   {
-    "code": "number-of-distinct-averages",
-    "problemNumber": 2465,
-    "name": "Number of Distinct Averages",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2465,
+    "title": "Number of Distinct Averages",
+    "titleSlug": "number-of-distinct-averages"
   },
   {
-    "code": "convert-the-temperature",
-    "problemNumber": 2469,
-    "name": "Convert the Temperature",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2469,
+    "title": "Convert the Temperature",
+    "titleSlug": "convert-the-temperature"
   },
   {
-    "code": "number-of-unequal-triplets-in-array",
-    "problemNumber": 2475,
-    "name": "Number of Unequal Triplets in Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2475,
+    "title": "Number of Unequal Triplets in Array",
+    "titleSlug": "number-of-unequal-triplets-in-array"
   },
   {
-    "code": "minimum-cuts-to-divide-a-circle",
-    "problemNumber": 2481,
-    "name": "Minimum Cuts to Divide a Circle",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2481,
+    "title": "Minimum Cuts to Divide a Circle",
+    "titleSlug": "minimum-cuts-to-divide-a-circle"
   },
   {
-    "code": "find-the-pivot-integer",
-    "problemNumber": 2485,
-    "name": "Find the Pivot Integer",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2485,
+    "title": "Find the Pivot Integer",
+    "titleSlug": "find-the-pivot-integer"
   },
   {
-    "code": "circular-sentence",
-    "problemNumber": 2490,
-    "name": "Circular Sentence",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2490,
+    "title": "Circular Sentence",
+    "titleSlug": "circular-sentence"
   },
   {
-    "code": "maximum-value-of-a-string-in-an-array",
-    "problemNumber": 2496,
-    "name": "Maximum Value of a String in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2496,
+    "title": "Maximum Value of a String in an Array",
+    "titleSlug": "maximum-value-of-a-string-in-an-array"
   },
   {
-    "code": "delete-greatest-value-in-each-row",
-    "problemNumber": 2500,
-    "name": "Delete Greatest Value in Each Row",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2500,
+    "title": "Delete Greatest Value in Each Row",
+    "titleSlug": "delete-greatest-value-in-each-row"
   },
   {
-    "code": "count-pairs-of-similar-strings",
-    "problemNumber": 2506,
-    "name": "Count Pairs Of Similar Strings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2506,
+    "title": "Count Pairs Of Similar Strings",
+    "titleSlug": "count-pairs-of-similar-strings"
   },
   {
-    "code": "maximum-enemy-forts-that-can-be-captured",
-    "problemNumber": 2511,
-    "name": "Maximum Enemy Forts That Can Be Captured",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2511,
+    "title": "Maximum Enemy Forts That Can Be Captured",
+    "titleSlug": "maximum-enemy-forts-that-can-be-captured"
   },
   {
-    "code": "shortest-distance-to-target-string-in-a-circular-array",
-    "problemNumber": 2515,
-    "name": "Shortest Distance to Target String in a Circular Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2515,
+    "title": "Shortest Distance to Target String in a Circular Array",
+    "titleSlug": "shortest-distance-to-target-string-in-a-circular-array"
   },
   {
-    "code": "count-the-digits-that-divide-a-number",
-    "problemNumber": 2520,
-    "name": "Count the Digits That Divide a Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2520,
+    "title": "Count the Digits That Divide a Number",
+    "titleSlug": "count-the-digits-that-divide-a-number"
   },
   {
-    "code": "categorize-box-according-to-criteria",
-    "problemNumber": 2525,
-    "name": "Categorize Box According to Criteria",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2525,
+    "title": "Categorize Box According to Criteria",
+    "titleSlug": "categorize-box-according-to-criteria"
   },
   {
-    "code": "maximum-count-of-positive-integer-and-negative-integer",
-    "problemNumber": 2529,
-    "name": "Maximum Count of Positive Integer and Negative Integer",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2529,
+    "title": "Maximum Count of Positive Integer and Negative Integer",
+    "titleSlug": "maximum-count-of-positive-integer-and-negative-integer"
   },
   {
-    "code": "difference-between-element-sum-and-digit-sum-of-an-array",
-    "problemNumber": 2535,
-    "name": "Difference Between Element Sum and Digit Sum of an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2535,
+    "title": "Difference Between Element Sum and Digit Sum of an Array",
+    "titleSlug": "difference-between-element-sum-and-digit-sum-of-an-array"
   },
   {
-    "code": "minimum-common-value",
-    "problemNumber": 2540,
-    "name": "Minimum Common Value",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2540,
+    "title": "Minimum Common Value",
+    "titleSlug": "minimum-common-value"
   },
   {
-    "code": "alternating-digit-sum",
-    "problemNumber": 2544,
-    "name": "Alternating Digit Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2544,
+    "title": "Alternating Digit Sum",
+    "titleSlug": "alternating-digit-sum"
   },
   {
-    "code": "count-distinct-numbers-on-board",
-    "problemNumber": 2549,
-    "name": "Count Distinct Numbers on Board",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2549,
+    "title": "Count Distinct Numbers on Board",
+    "titleSlug": "count-distinct-numbers-on-board"
   },
   {
-    "code": "separate-the-digits-in-an-array",
-    "problemNumber": 2553,
-    "name": "Separate the Digits in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2553,
+    "title": "Separate the Digits in an Array",
+    "titleSlug": "separate-the-digits-in-an-array"
   },
   {
-    "code": "take-gifts-from-the-richest-pile",
-    "problemNumber": 2558,
-    "name": "Take Gifts From the Richest Pile",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2558,
+    "title": "Take Gifts From the Richest Pile",
+    "titleSlug": "take-gifts-from-the-richest-pile"
   },
   {
-    "code": "find-the-array-concatenation-value",
-    "problemNumber": 2562,
-    "name": "Find the Array Concatenation Value",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2562,
+    "title": "Find the Array Concatenation Value",
+    "titleSlug": "find-the-array-concatenation-value"
   },
   {
-    "code": "maximum-difference-by-remapping-a-digit",
-    "problemNumber": 2566,
-    "name": "Maximum Difference by Remapping a Digit",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2566,
+    "title": "Maximum Difference by Remapping a Digit",
+    "titleSlug": "maximum-difference-by-remapping-a-digit"
   },
   {
-    "code": "merge-two-2d-arrays-by-summing-values",
-    "problemNumber": 2570,
-    "name": "Merge Two 2D Arrays by Summing Values",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2570,
+    "title": "Merge Two 2D Arrays by Summing Values",
+    "titleSlug": "merge-two-2d-arrays-by-summing-values"
   },
   {
-    "code": "left-and-right-sum-differences",
-    "problemNumber": 2574,
-    "name": "Left and Right Sum Differences",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2574,
+    "title": "Left and Right Sum Differences",
+    "titleSlug": "left-and-right-sum-differences"
   },
   {
-    "code": "split-with-minimum-sum",
-    "problemNumber": 2578,
-    "name": "Split With Minimum Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2578,
+    "title": "Split With Minimum Sum",
+    "titleSlug": "split-with-minimum-sum"
   },
   {
-    "code": "pass-the-pillow",
-    "problemNumber": 2582,
-    "name": "Pass the Pillow",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2582,
+    "title": "Pass the Pillow",
+    "titleSlug": "pass-the-pillow"
   },
   {
-    "code": "count-the-number-of-vowel-strings-in-range",
-    "problemNumber": 2586,
-    "name": "Count the Number of Vowel Strings in Range",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2586,
+    "title": "Count the Number of Vowel Strings in Range",
+    "titleSlug": "count-the-number-of-vowel-strings-in-range"
   },
   {
-    "code": "distribute-money-to-maximum-children",
-    "problemNumber": 2591,
-    "name": "Distribute Money to Maximum Children",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2591,
+    "title": "Distribute Money to Maximum Children",
+    "titleSlug": "distribute-money-to-maximum-children"
   },
   {
-    "code": "number-of-even-and-odd-bits",
-    "problemNumber": 2595,
-    "name": "Number of Even and Odd Bits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2595,
+    "title": "Number of Even and Odd Bits",
+    "titleSlug": "number-of-even-and-odd-bits"
   },
   {
-    "code": "k-items-with-the-maximum-sum",
-    "problemNumber": 2600,
-    "name": "K Items With the Maximum Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2600,
+    "title": "K Items With the Maximum Sum",
+    "titleSlug": "k-items-with-the-maximum-sum"
   },
   {
-    "code": "form-smallest-number-from-two-digit-arrays",
-    "problemNumber": 2605,
-    "name": "Form Smallest Number From Two Digit Arrays",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2605,
+    "title": "Form Smallest Number From Two Digit Arrays",
+    "titleSlug": "form-smallest-number-from-two-digit-arrays"
   },
   {
-    "code": "find-the-longest-balanced-substring-of-a-binary-string",
-    "problemNumber": 2609,
-    "name": "Find the Longest Balanced Substring of a Binary String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2609,
+    "title": "Find the Longest Balanced Substring of a Binary String",
+    "titleSlug": "find-the-longest-balanced-substring-of-a-binary-string"
   },
   {
-    "code": "prime-in-diagonal",
-    "problemNumber": 2614,
-    "name": "Prime In Diagonal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2614,
+    "title": "Prime In Diagonal",
+    "titleSlug": "prime-in-diagonal"
   },
   {
-    "code": "find-the-width-of-columns-of-a-grid",
-    "problemNumber": 2639,
-    "name": "Find the Width of Columns of a Grid",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2639,
+    "title": "Find the Width of Columns of a Grid",
+    "titleSlug": "find-the-width-of-columns-of-a-grid"
   },
   {
-    "code": "row-with-maximum-ones",
-    "problemNumber": 2643,
-    "name": "Row With Maximum Ones",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2643,
+    "title": "Row With Maximum Ones",
+    "titleSlug": "row-with-maximum-ones"
   },
   {
-    "code": "find-the-maximum-divisibility-score",
-    "problemNumber": 2644,
-    "name": "Find the Maximum Divisibility Score",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2644,
+    "title": "Find the Maximum Divisibility Score",
+    "titleSlug": "find-the-maximum-divisibility-score"
   },
   {
-    "code": "calculate-delayed-arrival-time",
-    "problemNumber": 2651,
-    "name": "Calculate Delayed Arrival Time",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2651,
+    "title": "Calculate Delayed Arrival Time",
+    "titleSlug": "calculate-delayed-arrival-time"
   },
   {
-    "code": "sum-multiples",
-    "problemNumber": 2652,
-    "name": "Sum Multiples",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2652,
+    "title": "Sum Multiples",
+    "titleSlug": "sum-multiples"
   },
   {
-    "code": "maximum-sum-with-exactly-k-elements",
-    "problemNumber": 2656,
-    "name": "Maximum Sum With Exactly K Elements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2656,
+    "title": "Maximum Sum With Exactly K Elements",
+    "titleSlug": "maximum-sum-with-exactly-k-elements"
   },
   {
-    "code": "determine-the-winner-of-a-bowling-game",
-    "problemNumber": 2660,
-    "name": "Determine the Winner of a Bowling Game",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2660,
+    "title": "Determine the Winner of a Bowling Game",
+    "titleSlug": "determine-the-winner-of-a-bowling-game"
   },
   {
-    "code": "find-the-distinct-difference-array",
-    "problemNumber": 2670,
-    "name": "Find the Distinct Difference Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2670,
+    "title": "Find the Distinct Difference Array",
+    "titleSlug": "find-the-distinct-difference-array"
   },
   {
-    "code": "number-of-senior-citizens",
-    "problemNumber": 2678,
-    "name": "Number of Senior Citizens",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2678,
+    "title": "Number of Senior Citizens",
+    "titleSlug": "number-of-senior-citizens"
   },
   {
-    "code": "find-the-losers-of-the-circular-game",
-    "problemNumber": 2682,
-    "name": "Find the Losers of the Circular Game",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2682,
+    "title": "Find the Losers of the Circular Game",
+    "titleSlug": "find-the-losers-of-the-circular-game"
   },
   {
-    "code": "extract-kth-character-from-the-rope-tree",
-    "problemNumber": 2689,
-    "name": "Extract Kth Character From The Rope Tree",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 2689,
+    "title": "Extract Kth Character From The Rope Tree",
+    "titleSlug": "extract-kth-character-from-the-rope-tree"
   },
   {
-    "code": "minimum-string-length-after-removing-substrings",
-    "problemNumber": 2696,
-    "name": "Minimum String Length After Removing Substrings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2696,
+    "title": "Minimum String Length After Removing Substrings",
+    "titleSlug": "minimum-string-length-after-removing-substrings"
   },
   {
-    "code": "lexicographically-smallest-palindrome",
-    "problemNumber": 2697,
-    "name": "Lexicographically Smallest Palindrome",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2697,
+    "title": "Lexicographically Smallest Palindrome",
+    "titleSlug": "lexicographically-smallest-palindrome"
   },
   {
-    "code": "buy-two-chocolates",
-    "problemNumber": 2706,
-    "name": "Buy Two Chocolates",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2706,
+    "title": "Buy Two Chocolates",
+    "titleSlug": "buy-two-chocolates"
   },
   {
-    "code": "remove-trailing-zeros-from-a-string",
-    "problemNumber": 2710,
-    "name": "Remove Trailing Zeros From a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2710,
+    "title": "Remove Trailing Zeros From a String",
+    "titleSlug": "remove-trailing-zeros-from-a-string"
   },
   {
-    "code": "minimize-string-length",
-    "problemNumber": 2716,
-    "name": "Minimize String Length",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2716,
+    "title": "Minimize String Length",
+    "titleSlug": "minimize-string-length"
   },
   {
-    "code": "semi-ordered-permutation",
-    "problemNumber": 2717,
-    "name": "Semi-Ordered Permutation",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2717,
+    "title": "Semi-Ordered Permutation",
+    "titleSlug": "semi-ordered-permutation"
   },
   {
-    "code": "count-houses-in-a-circular-street",
-    "problemNumber": 2728,
-    "name": "Count Houses in a Circular Street",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 2728,
+    "title": "Count Houses in a Circular Street",
+    "titleSlug": "count-houses-in-a-circular-street"
   },
   {
-    "code": "check-if-the-number-is-fascinating",
-    "problemNumber": 2729,
-    "name": "Check if The Number is Fascinating",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2729,
+    "title": "Check if The Number is Fascinating",
+    "titleSlug": "check-if-the-number-is-fascinating"
   },
   {
-    "code": "neither-minimum-nor-maximum",
-    "problemNumber": 2733,
-    "name": "Neither Minimum nor Maximum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2733,
+    "title": "Neither Minimum nor Maximum",
+    "titleSlug": "neither-minimum-nor-maximum"
   },
   {
-    "code": "total-distance-traveled",
-    "problemNumber": 2739,
-    "name": "Total Distance Traveled",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2739,
+    "title": "Total Distance Traveled",
+    "titleSlug": "total-distance-traveled"
   },
   {
-    "code": "find-maximum-number-of-string-pairs",
-    "problemNumber": 2744,
-    "name": "Find Maximum Number of String Pairs",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2744,
+    "title": "Find Maximum Number of String Pairs",
+    "titleSlug": "find-maximum-number-of-string-pairs"
   },
   {
-    "code": "number-of-beautiful-pairs",
-    "problemNumber": 2748,
-    "name": "Number of Beautiful Pairs",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2748,
+    "title": "Number of Beautiful Pairs",
+    "titleSlug": "number-of-beautiful-pairs"
   },
   {
-    "code": "longest-even-odd-subarray-with-threshold",
-    "problemNumber": 2760,
-    "name": "Longest Even Odd Subarray With Threshold",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2760,
+    "title": "Longest Even Odd Subarray With Threshold",
+    "titleSlug": "longest-even-odd-subarray-with-threshold"
   },
   {
-    "code": "longest-alternating-subarray",
-    "problemNumber": 2765,
-    "name": "Longest Alternating Subarray",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2765,
+    "title": "Longest Alternating Subarray",
+    "titleSlug": "longest-alternating-subarray"
   },
   {
-    "code": "find-the-maximum-achievable-number",
-    "problemNumber": 2769,
-    "name": "Find the Maximum Achievable Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2769,
+    "title": "Find the Maximum Achievable Number",
+    "titleSlug": "find-the-maximum-achievable-number"
   },
   {
-    "code": "sum-of-squares-of-special-elements",
-    "problemNumber": 2778,
-    "name": "Sum of Squares of Special Elements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2778,
+    "title": "Sum of Squares of Special Elements",
+    "titleSlug": "sum-of-squares-of-special-elements"
   },
   {
-    "code": "check-if-array-is-good",
-    "problemNumber": 2784,
-    "name": "Check if Array is Good",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2784,
+    "title": "Check if Array is Good",
+    "titleSlug": "check-if-array-is-good"
   },
   {
-    "code": "split-strings-by-separator",
-    "problemNumber": 2788,
-    "name": "Split Strings by Separator",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2788,
+    "title": "Split Strings by Separator",
+    "titleSlug": "split-strings-by-separator"
   },
   {
-    "code": "number-of-employees-who-met-the-target",
-    "problemNumber": 2798,
-    "name": "Number of Employees Who Met the Target",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2798,
+    "title": "Number of Employees Who Met the Target",
+    "titleSlug": "number-of-employees-who-met-the-target"
   },
   {
-    "code": "account-balance-after-rounded-purchase",
-    "problemNumber": 2806,
-    "name": "Account Balance After Rounded Purchase",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2806,
+    "title": "Account Balance After Rounded Purchase",
+    "titleSlug": "account-balance-after-rounded-purchase"
   },
   {
-    "code": "faulty-keyboard",
-    "problemNumber": 2810,
-    "name": "Faulty Keyboard",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2810,
+    "title": "Faulty Keyboard",
+    "titleSlug": "faulty-keyboard"
   },
   {
-    "code": "max-pair-sum-in-an-array",
-    "problemNumber": 2815,
-    "name": "Max Pair Sum in an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2815,
+    "title": "Max Pair Sum in an Array",
+    "titleSlug": "max-pair-sum-in-an-array"
   },
   {
-    "code": "count-pairs-whose-sum-is-less-than-target",
-    "problemNumber": 2824,
-    "name": "Count Pairs Whose Sum is Less than Target",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2824,
+    "title": "Count Pairs Whose Sum is Less than Target",
+    "titleSlug": "count-pairs-whose-sum-is-less-than-target"
   },
   {
-    "code": "check-if-a-string-is-an-acronym-of-words",
-    "problemNumber": 2828,
-    "name": "Check if a String Is an Acronym of Words",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2828,
+    "title": "Check if a String Is an Acronym of Words",
+    "titleSlug": "check-if-a-string-is-an-acronym-of-words"
   },
   {
-    "code": "furthest-point-from-origin",
-    "problemNumber": 2833,
-    "name": "Furthest Point From Origin",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2833,
+    "title": "Furthest Point From Origin",
+    "titleSlug": "furthest-point-from-origin"
   },
   {
-    "code": "check-if-strings-can-be-made-equal-with-operations-i",
-    "problemNumber": 2839,
-    "name": "Check if Strings Can be Made Equal With Operations I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2839,
+    "title": "Check if Strings Can be Made Equal With Operations I",
+    "titleSlug": "check-if-strings-can-be-made-equal-with-operations-i"
   },
   {
-    "code": "count-symmetric-integers",
-    "problemNumber": 2843,
-    "name": "Count Symmetric Integers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2843,
+    "title": "Count Symmetric Integers",
+    "titleSlug": "count-symmetric-integers"
   },
   {
-    "code": "points-that-intersect-with-cars",
-    "problemNumber": 2848,
-    "name": "Points That Intersect With Cars",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2848,
+    "title": "Points That Intersect With Cars",
+    "titleSlug": "points-that-intersect-with-cars"
   },
   {
-    "code": "minimum-right-shifts-to-sort-the-array",
-    "problemNumber": 2855,
-    "name": "Minimum Right Shifts to Sort the Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2855,
+    "title": "Minimum Right Shifts to Sort the Array",
+    "titleSlug": "minimum-right-shifts-to-sort-the-array"
   },
   {
-    "code": "sum-of-values-at-indices-with-k-set-bits",
-    "problemNumber": 2859,
-    "name": "Sum of Values at Indices With K Set Bits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2859,
+    "title": "Sum of Values at Indices With K Set Bits",
+    "titleSlug": "sum-of-values-at-indices-with-k-set-bits"
   },
   {
-    "code": "maximum-odd-binary-number",
-    "problemNumber": 2864,
-    "name": "Maximum Odd Binary Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2864,
+    "title": "Maximum Odd Binary Number",
+    "titleSlug": "maximum-odd-binary-number"
   },
   {
-    "code": "minimum-operations-to-collect-elements",
-    "problemNumber": 2869,
-    "name": "Minimum Operations to Collect Elements",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2869,
+    "title": "Minimum Operations to Collect Elements",
+    "titleSlug": "minimum-operations-to-collect-elements"
   },
   {
-    "code": "maximum-value-of-an-ordered-triplet-i",
-    "problemNumber": 2873,
-    "name": "Maximum Value of an Ordered Triplet I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2873,
+    "title": "Maximum Value of an Ordered Triplet I",
+    "titleSlug": "maximum-value-of-an-ordered-triplet-i"
   },
   {
-    "code": "divisible-and-non-divisible-sums-difference",
-    "problemNumber": 2894,
-    "name": "Divisible and Non-divisible Sums Difference",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2894,
+    "title": "Divisible and Non-divisible Sums Difference",
+    "titleSlug": "divisible-and-non-divisible-sums-difference"
   },
   {
-    "code": "last-visited-integers",
-    "problemNumber": 2899,
-    "name": "Last Visited Integers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2899,
+    "title": "Last Visited Integers",
+    "titleSlug": "last-visited-integers"
   },
   {
-    "code": "longest-unequal-adjacent-groups-subsequence-i",
-    "problemNumber": 2900,
-    "name": "Longest Unequal Adjacent Groups Subsequence I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2900,
+    "title": "Longest Unequal Adjacent Groups Subsequence I",
+    "titleSlug": "longest-unequal-adjacent-groups-subsequence-i"
   },
   {
-    "code": "find-indices-with-index-and-value-difference-i",
-    "problemNumber": 2903,
-    "name": "Find Indices With Index and Value Difference I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2903,
+    "title": "Find Indices With Index and Value Difference I",
+    "titleSlug": "find-indices-with-index-and-value-difference-i"
   },
   {
-    "code": "minimum-sum-of-mountain-triplets-i",
-    "problemNumber": 2908,
-    "name": "Minimum Sum of Mountain Triplets I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2908,
+    "title": "Minimum Sum of Mountain Triplets I",
+    "titleSlug": "minimum-sum-of-mountain-triplets-i"
   },
   {
-    "code": "subarrays-distinct-element-sum-of-squares-i",
-    "problemNumber": 2913,
-    "name": "Subarrays Distinct Element Sum of Squares I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2913,
+    "title": "Subarrays Distinct Element Sum of Squares I",
+    "titleSlug": "subarrays-distinct-element-sum-of-squares-i"
   },
   {
-    "code": "find-the-k-or-of-an-array",
-    "problemNumber": 2917,
-    "name": "Find the K-or of an Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2917,
+    "title": "Find the K-or of an Array",
+    "titleSlug": "find-the-k-or-of-an-array"
   },
   {
-    "code": "find-champion-i",
-    "problemNumber": 2923,
-    "name": "Find Champion I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2923,
+    "title": "Find Champion I",
+    "titleSlug": "find-champion-i"
   },
   {
-    "code": "distribute-candies-among-children-i",
-    "problemNumber": 2928,
-    "name": "Distribute Candies Among Children I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2928,
+    "title": "Distribute Candies Among Children I",
+    "titleSlug": "distribute-candies-among-children-i"
   },
   {
-    "code": "maximum-strong-pair-xor-i",
-    "problemNumber": 2932,
-    "name": "Maximum Strong Pair XOR I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2932,
+    "title": "Maximum Strong Pair XOR I",
+    "titleSlug": "maximum-strong-pair-xor-i"
   },
   {
-    "code": "make-three-strings-equal",
-    "problemNumber": 2937,
-    "name": "Make Three Strings Equal",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2937,
+    "title": "Make Three Strings Equal",
+    "titleSlug": "make-three-strings-equal"
   },
   {
-    "code": "find-words-containing-character",
-    "problemNumber": 2942,
-    "name": "Find Words Containing Character",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2942,
+    "title": "Find Words Containing Character",
+    "titleSlug": "find-words-containing-character"
   },
   {
-    "code": "matrix-similarity-after-cyclic-shifts",
-    "problemNumber": 2946,
-    "name": "Matrix Similarity After Cyclic Shifts",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2946,
+    "title": "Matrix Similarity After Cyclic Shifts",
+    "titleSlug": "matrix-similarity-after-cyclic-shifts"
   },
   {
-    "code": "find-the-peaks",
-    "problemNumber": 2951,
-    "name": "Find the Peaks",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2951,
+    "title": "Find the Peaks",
+    "titleSlug": "find-the-peaks"
   },
   {
-    "code": "find-common-elements-between-two-arrays",
-    "problemNumber": 2956,
-    "name": "Find Common Elements Between Two Arrays",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2956,
+    "title": "Find Common Elements Between Two Arrays",
+    "titleSlug": "find-common-elements-between-two-arrays"
   },
   {
-    "code": "count-tested-devices-after-test-operations",
-    "problemNumber": 2960,
-    "name": "Count Tested Devices After Test Operations",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2960,
+    "title": "Count Tested Devices After Test Operations",
+    "titleSlug": "count-tested-devices-after-test-operations"
   },
   {
-    "code": "find-missing-and-repeated-values",
-    "problemNumber": 2965,
-    "name": "Find Missing and Repeated Values",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2965,
+    "title": "Find Missing and Repeated Values",
+    "titleSlug": "find-missing-and-repeated-values"
   },
   {
-    "code": "count-the-number-of-incremovable-subarrays-i",
-    "problemNumber": 2970,
-    "name": "Count the Number of Incremovable Subarrays I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2970,
+    "title": "Count the Number of Incremovable Subarrays I",
+    "titleSlug": "count-the-number-of-incremovable-subarrays-i"
   },
   {
-    "code": "minimum-number-game",
-    "problemNumber": 2974,
-    "name": "Minimum Number Game",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2974,
+    "title": "Minimum Number Game",
+    "titleSlug": "minimum-number-game"
   },
   {
-    "code": "check-if-bitwise-or-has-trailing-zeros",
-    "problemNumber": 2980,
-    "name": "Check if Bitwise OR Has Trailing Zeros",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2980,
+    "title": "Check if Bitwise OR Has Trailing Zeros",
+    "titleSlug": "check-if-bitwise-or-has-trailing-zeros"
   },
   {
-    "code": "smallest-missing-integer-greater-than-sequential-prefix-sum",
-    "problemNumber": 2996,
-    "name": "Smallest Missing Integer Greater Than Sequential Prefix Sum",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 2996,
+    "title": "Smallest Missing Integer Greater Than Sequential Prefix Sum",
+    "titleSlug": "smallest-missing-integer-greater-than-sequential-prefix-sum"
   },
   {
-    "code": "maximum-area-of-longest-diagonal-rectangle",
-    "problemNumber": 3000,
-    "name": "Maximum Area of Longest Diagonal Rectangle",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3000,
+    "title": "Maximum Area of Longest Diagonal Rectangle",
+    "titleSlug": "maximum-area-of-longest-diagonal-rectangle"
   },
   {
-    "code": "count-elements-with-maximum-frequency",
-    "problemNumber": 3005,
-    "name": "Count Elements With Maximum Frequency",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3005,
+    "title": "Count Elements With Maximum Frequency",
+    "titleSlug": "count-elements-with-maximum-frequency"
   },
   {
-    "code": "divide-an-array-into-subarrays-with-minimum-cost-i",
-    "problemNumber": 3010,
-    "name": "Divide an Array Into Subarrays With Minimum Cost I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3010,
+    "title": "Divide an Array Into Subarrays With Minimum Cost I",
+    "titleSlug": "divide-an-array-into-subarrays-with-minimum-cost-i"
   },
   {
-    "code": "minimum-number-of-pushes-to-type-word-i",
-    "problemNumber": 3014,
-    "name": "Minimum Number of Pushes to Type Word I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3014,
+    "title": "Minimum Number of Pushes to Type Word I",
+    "titleSlug": "minimum-number-of-pushes-to-type-word-i"
   },
   {
-    "code": "number-of-changing-keys",
-    "problemNumber": 3019,
-    "name": "Number of Changing Keys",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3019,
+    "title": "Number of Changing Keys",
+    "titleSlug": "number-of-changing-keys"
   },
   {
-    "code": "type-of-triangle",
-    "problemNumber": 3024,
-    "name": "Type of Triangle",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3024,
+    "title": "Type of Triangle",
+    "titleSlug": "type-of-triangle"
   },
   {
-    "code": "ant-on-the-boundary",
-    "problemNumber": 3028,
-    "name": "Ant on the Boundary",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3028,
+    "title": "Ant on the Boundary",
+    "titleSlug": "ant-on-the-boundary"
   },
   {
-    "code": "count-numbers-with-unique-digits-ii",
-    "problemNumber": 3032,
-    "name": "Count Numbers With Unique Digits II",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 3032,
+    "title": "Count Numbers With Unique Digits II",
+    "titleSlug": "count-numbers-with-unique-digits-ii"
   },
   {
-    "code": "modify-the-matrix",
-    "problemNumber": 3033,
-    "name": "Modify the Matrix",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3033,
+    "title": "Modify the Matrix",
+    "titleSlug": "modify-the-matrix"
   },
   {
-    "code": "maximum-number-of-operations-with-the-same-score-i",
-    "problemNumber": 3038,
-    "name": "Maximum Number of Operations With the Same Score I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3038,
+    "title": "Maximum Number of Operations With the Same Score I",
+    "titleSlug": "maximum-number-of-operations-with-the-same-score-i"
   },
   {
-    "code": "count-prefix-and-suffix-pairs-i",
-    "problemNumber": 3042,
-    "name": "Count Prefix and Suffix Pairs I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3042,
+    "title": "Count Prefix and Suffix Pairs I",
+    "titleSlug": "count-prefix-and-suffix-pairs-i"
   },
   {
-    "code": "split-the-array",
-    "problemNumber": 3046,
-    "name": "Split the Array",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3046,
+    "title": "Split the Array",
+    "titleSlug": "split-the-array"
   },
   {
-    "code": "winner-of-the-linked-list-game",
-    "problemNumber": 3062,
-    "name": "Winner of the Linked List Game",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 3062,
+    "title": "Winner of the Linked List Game",
+    "titleSlug": "winner-of-the-linked-list-game"
   },
   {
-    "code": "linked-list-frequency",
-    "problemNumber": 3063,
-    "name": "Linked List Frequency",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 3063,
+    "title": "Linked List Frequency",
+    "titleSlug": "linked-list-frequency"
   },
   {
-    "code": "minimum-operations-to-exceed-threshold-value-i",
-    "problemNumber": 3065,
-    "name": "Minimum Operations to Exceed Threshold Value I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3065,
+    "title": "Minimum Operations to Exceed Threshold Value I",
+    "titleSlug": "minimum-operations-to-exceed-threshold-value-i"
   },
   {
-    "code": "distribute-elements-into-two-arrays-i",
-    "problemNumber": 3069,
-    "name": "Distribute Elements Into Two Arrays I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3069,
+    "title": "Distribute Elements Into Two Arrays I",
+    "titleSlug": "distribute-elements-into-two-arrays-i"
   },
   {
-    "code": "apple-redistribution-into-boxes",
-    "problemNumber": 3074,
-    "name": "Apple Redistribution into Boxes",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3074,
+    "title": "Apple Redistribution into Boxes",
+    "titleSlug": "apple-redistribution-into-boxes"
   },
   {
-    "code": "find-the-sum-of-encrypted-integers",
-    "problemNumber": 3079,
-    "name": "Find the Sum of Encrypted Integers",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3079,
+    "title": "Find the Sum of Encrypted Integers",
+    "titleSlug": "find-the-sum-of-encrypted-integers"
   },
   {
-    "code": "existence-of-a-substring-in-a-string-and-its-reverse",
-    "problemNumber": 3083,
-    "name": "Existence of a Substring in a String and Its Reverse",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3083,
+    "title": "Existence of a Substring in a String and Its Reverse",
+    "titleSlug": "existence-of-a-substring-in-a-string-and-its-reverse"
   },
   {
-    "code": "maximum-length-substring-with-two-occurrences",
-    "problemNumber": 3090,
-    "name": "Maximum Length Substring With Two Occurrences",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3090,
+    "title": "Maximum Length Substring With Two Occurrences",
+    "titleSlug": "maximum-length-substring-with-two-occurrences"
   },
   {
-    "code": "shortest-subarray-with-or-at-least-k-i",
-    "problemNumber": 3095,
-    "name": "Shortest Subarray With OR at Least K I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3095,
+    "title": "Shortest Subarray With OR at Least K I",
+    "titleSlug": "shortest-subarray-with-or-at-least-k-i"
   },
   {
-    "code": "harshad-number",
-    "problemNumber": 3099,
-    "name": "Harshad Number",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3099,
+    "title": "Harshad Number",
+    "titleSlug": "harshad-number"
   },
   {
-    "code": "longest-strictly-increasing-or-strictly-decreasing-subarray",
-    "problemNumber": 3105,
-    "name": "Longest Strictly Increasing or Strictly Decreasing Subarray",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3105,
+    "title": "Longest Strictly Increasing or Strictly Decreasing Subarray",
+    "titleSlug": "longest-strictly-increasing-or-strictly-decreasing-subarray"
   },
   {
-    "code": "score-of-a-string",
-    "problemNumber": 3110,
-    "name": "Score of a String",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3110,
+    "title": "Score of a String",
+    "titleSlug": "score-of-a-string"
   },
   {
-    "code": "latest-time-you-can-obtain-after-replacing-characters",
-    "problemNumber": 3114,
-    "name": "Latest Time You Can Obtain After Replacing Characters",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3114,
+    "title": "Latest Time You Can Obtain After Replacing Characters",
+    "titleSlug": "latest-time-you-can-obtain-after-replacing-characters"
   },
   {
-    "code": "count-the-number-of-special-characters-i",
-    "problemNumber": 3120,
-    "name": "Count the Number of Special Characters I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3120,
+    "title": "Count the Number of Special Characters I",
+    "titleSlug": "count-the-number-of-special-characters-i"
   },
   {
-    "code": "make-a-square-with-the-same-color",
-    "problemNumber": 3127,
-    "name": "Make a Square with the Same Color",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3127,
+    "title": "Make a Square with the Same Color",
+    "titleSlug": "make-a-square-with-the-same-color"
   },
   {
-    "code": "find-the-integer-added-to-array-i",
-    "problemNumber": 3131,
-    "name": "Find the Integer Added to Array I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3131,
+    "title": "Find the Integer Added to Array I",
+    "titleSlug": "find-the-integer-added-to-array-i"
   },
   {
-    "code": "valid-word",
-    "problemNumber": 3136,
-    "name": "Valid Word",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3136,
+    "title": "Valid Word",
+    "titleSlug": "valid-word"
   },
   {
-    "code": "check-if-grid-satisfies-conditions",
-    "problemNumber": 3142,
-    "name": "Check if Grid Satisfies Conditions",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3142,
+    "title": "Check if Grid Satisfies Conditions",
+    "titleSlug": "check-if-grid-satisfies-conditions"
   },
   {
-    "code": "permutation-difference-between-two-strings",
-    "problemNumber": 3146,
-    "name": "Permutation Difference between Two Strings",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3146,
+    "title": "Permutation Difference between Two Strings",
+    "titleSlug": "permutation-difference-between-two-strings"
   },
   {
-    "code": "special-array-i",
-    "problemNumber": 3151,
-    "name": "Special Array I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3151,
+    "title": "Special Array I",
+    "titleSlug": "special-array-i"
   },
   {
-    "code": "find-the-xor-of-numbers-which-appear-twice",
-    "problemNumber": 3158,
-    "name": "Find the XOR of Numbers Which Appear Twice",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3158,
+    "title": "Find the XOR of Numbers Which Appear Twice",
+    "titleSlug": "find-the-xor-of-numbers-which-appear-twice"
   },
   {
-    "code": "find-the-number-of-good-pairs-i",
-    "problemNumber": 3162,
-    "name": "Find the Number of Good Pairs I",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3162,
+    "title": "Find the Number of Good Pairs I",
+    "titleSlug": "find-the-number-of-good-pairs-i"
   },
   {
-    "code": "minimum-number-of-chairs-in-a-waiting-room",
-    "problemNumber": 3168,
-    "name": "Minimum Number of Chairs in a Waiting Room",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3168,
+    "title": "Minimum Number of Chairs in a Waiting Room",
+    "titleSlug": "minimum-number-of-chairs-in-a-waiting-room"
   },
   {
-    "code": "bitwise-or-of-adjacent-elements",
-    "problemNumber": 3173,
-    "name": "Bitwise OR of Adjacent Elements",
     "difficulty": "Easy",
-    "isPremium": true
+    "isPaidOnly": true,
+    "questionFrontendId": 3173,
+    "title": "Bitwise OR of Adjacent Elements",
+    "titleSlug": "bitwise-or-of-adjacent-elements"
   },
   {
-    "code": "clear-digits",
-    "problemNumber": 3174,
-    "name": "Clear Digits",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3174,
+    "title": "Clear Digits",
+    "titleSlug": "clear-digits"
   },
   {
-    "code": "find-the-child-who-has-the-ball-after-k-seconds",
-    "problemNumber": 3178,
-    "name": "Find the Child Who Has the Ball After K Seconds",
     "difficulty": "Easy",
-    "isPremium": false
+    "isPaidOnly": false,
+    "questionFrontendId": 3178,
+    "title": "Find the Child Who Has the Ball After K Seconds",
+    "titleSlug": "find-the-child-who-has-the-ball-after-k-seconds"
   }
 ]

--- a/tools/get-problem-list/src/main.ts
+++ b/tools/get-problem-list/src/main.ts
@@ -29,7 +29,7 @@ async function main(): Promise<void> {
     totalCount = data.totalNum;
 
     for (const question of data.questions) {
-      problemsMap.set(question.problemNumber, question);
+      problemsMap.set(question.questionFrontendId, question);
     }
 
     if (data.questions.length === 0) {
@@ -45,7 +45,7 @@ async function main(): Promise<void> {
   }
 
   const problems = [...problemsMap.values()].sort(
-    (a, b) => a.problemNumber - b.problemNumber,
+    (a, b) => a.questionFrontendId - b.questionFrontendId,
   );
   console.log(JSON.stringify(problems, null, 2));
 }

--- a/tools/leetcode-api/src/getActiveDailyCodingChallengeQuestion.ts
+++ b/tools/leetcode-api/src/getActiveDailyCodingChallengeQuestion.ts
@@ -18,23 +18,18 @@ const QUERY = `
   .trim()
   .replace(/\s+/g, " ");
 
-const questionParser = z
-  .object({
-    questionFrontendId: z
-      .string()
-      .trim()
-      .regex(/^[1-9][0-9]*$/)
-      .transform((value) => parseInt(value, 10)),
-    title: z.string().trim().min(1),
-    titleSlug: z
-      .string()
-      .trim()
-      .regex(/^[a-z0-9\-]+$/),
-  })
-  .transform(({ questionFrontendId, ...rest }) => ({
-    ...rest,
-    problemNumber: questionFrontendId,
-  }));
+const questionParser = z.object({
+  questionFrontendId: z
+    .string()
+    .trim()
+    .regex(/^[1-9][0-9]*$/)
+    .transform((value) => parseInt(value, 10)),
+  title: z.string().trim().min(1),
+  titleSlug: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9\-]+$/),
+});
 
 const activeDailyCodingChallengeQuestionParser = z
   .object({

--- a/tools/leetcode-api/src/getQuestionList.ts
+++ b/tools/leetcode-api/src/getQuestionList.ts
@@ -24,30 +24,20 @@ const QUERY = `
   .trim()
   .replace(/\s+/g, " ");
 
-const questionParser = z
-  .object({
-    difficulty: z.enum(["Easy", "Medium", "Hard"]),
-    isPaidOnly: z.boolean(),
-    questionFrontendId: z
-      .string()
-      .trim()
-      .regex(/^[1-9][0-9]*$/)
-      .transform((value) => parseInt(value, 10)),
-    title: z.string().trim().min(1),
-    titleSlug: z
-      .string()
-      .trim()
-      .regex(/^[a-z0-9\-]+$/),
-  })
-  .transform(
-    ({ titleSlug, questionFrontendId, title, difficulty, isPaidOnly }) => ({
-      code: titleSlug,
-      problemNumber: questionFrontendId,
-      name: title,
-      difficulty,
-      isPremium: isPaidOnly,
-    }),
-  );
+const questionParser = z.object({
+  difficulty: z.enum(["Easy", "Medium", "Hard"]),
+  isPaidOnly: z.boolean(),
+  questionFrontendId: z
+    .string()
+    .trim()
+    .regex(/^[1-9][0-9]*$/)
+    .transform((value) => parseInt(value, 10)),
+  title: z.string().trim().min(1),
+  titleSlug: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9\-]+$/),
+});
 
 export type QuestionListQuestion = z.infer<typeof questionParser>;
 

--- a/tools/leetcode-api/src/getSubmissionList.ts
+++ b/tools/leetcode-api/src/getSubmissionList.ts
@@ -40,7 +40,11 @@ const submissionParser = (() => {
     })
     .transform(({ question_id, title, title_slug, ...rest }) => ({
       ...rest,
-      question: { title, titleSlug: title_slug, problemNumber: question_id },
+      question: {
+        questionFrontendId: question_id,
+        title,
+        titleSlug: title_slug,
+      },
     }));
 })();
 

--- a/tools/post-potd/src/main.ts
+++ b/tools/post-potd/src/main.ts
@@ -29,7 +29,7 @@ async function main(): Promise<void> {
   const { question: potd } = await getPotd();
   const potdLink = `https://leetcode.com/problems/${potd.titleSlug}/`;
 
-  const message = `New LeetCode problem of the day! [${potd.problemNumber}. ${potd.title}](${potdLink})`;
+  const message = `New LeetCode problem of the day! [${potd.questionFrontendId}. ${potd.title}](${potdLink})`;
   await sendDiscordMessage(message);
   console.log(message);
 }


### PR DESCRIPTION
I'm slightly torn on this one. Although there are names that I'd prefer to those of the GraphQL field names, consistency has an advantage. Perhaps I'll revisit this later as the API expands a bit.
