### PR TITLE
Remove relative time from downloaded submissions metadata file

### DIFF
--- a/tools/eslint-config/eslint.config.js
+++ b/tools/eslint-config/eslint.config.js
@@ -90,7 +90,7 @@ module.exports = [
       "no-unused-private-class-members": "error",
 
       // TODO: explore the options in more detail
-      "no-unused-vars": "error",
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
 
       "no-use-before-define": [
         "error",


### PR DESCRIPTION
It's relative, so it will not be as useful longterm as the absolute timestamp.
