### PR TITLE
Add a `String.prototype.chars` to the adventure pack

### DIFF
--- a/tools/adventure-pack/src/__tests__/stringPrototypeChars.test.ts
+++ b/tools/adventure-pack/src/__tests__/stringPrototypeChars.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "@jest/globals";
+
+import "../stringPrototypeChars";
+
+describe("String.prototype.chars", () => {
+  it("can iterate over a string's characters", () => {
+    const iterator = "bonjour".chars();
+
+    expect(iterator.next().value).toBe("b");
+    expect(iterator.next().value).toBe("o");
+    expect(iterator.next().value).toBe("n");
+    expect(iterator.next().value).toBe("j");
+    expect(iterator.next().value).toBe("o");
+    expect(iterator.next().value).toBe("u");
+    expect(iterator.next().value).toBe("r");
+    expect(iterator.next().done).toBe(true);
+  });
+});

--- a/tools/adventure-pack/src/stringPrototypeChars.ts
+++ b/tools/adventure-pack/src/stringPrototypeChars.ts
@@ -1,0 +1,11 @@
+declare global {
+  interface String {
+    chars(): IterableIterator<string>;
+  }
+}
+
+String.prototype.chars = String.prototype[Symbol.iterator];
+
+// Needed to fix the error "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations. ts(2669)"
+// See: https://stackoverflow.com/questions/57132428/augmentations-for-the-global-scope-can-only-be-directly-nested-in-external-modul
+export {};


### PR DESCRIPTION
It's more fun to do `s.chars()` than `s[Symbol.iterator]()`.
