### PR TITLE
Add a `Number.isIntegerOrIntegerObject` to the adventure pack

### DIFF
--- a/tools/adventure-pack/package.json
+++ b/tools/adventure-pack/package.json
@@ -12,7 +12,6 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint .",
-    "start": "ts-node src/main.ts",
     "test": "jest",
     "typecheck": "tsc --project ."
   },

--- a/tools/adventure-pack/src/__tests__/numberIsIntegerOrIntegerObject.test.ts
+++ b/tools/adventure-pack/src/__tests__/numberIsIntegerOrIntegerObject.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "@jest/globals";
+
+import "../numberIsIntegerOrIntegerObject";
+
+describe("Number.isIntegerOrIntegerObject", () => {
+  it("returns true for integers", () => {
+    expect(Number.isIntegerOrIntegerObject(0)).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(1)).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(-1)).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(42)).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(1337)).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(-(10 ** 6))).toBe(true);
+  });
+
+  it("returns true for integer objects", () => {
+    expect(Number.isIntegerOrIntegerObject(new Number(0))).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(new Number(1))).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(new Number(-1))).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(new Number(42))).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(new Number(1337))).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(new Number(-(10 ** 6)))).toBe(true);
+  });
+
+  it("returns false for non-integer numbers", () => {
+    expect(Number.isIntegerOrIntegerObject(-5.3)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(2.5)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(Math.PI)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(Infinity)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(-Infinity)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(NaN)).toBe(false);
+  });
+
+  it("returns false for non-numbers", () => {
+    expect(Number.isIntegerOrIntegerObject("12")).toBe(false);
+    expect(Number.isIntegerOrIntegerObject("0")).toBe(false);
+    expect(Number.isIntegerOrIntegerObject("")).toBe(false);
+    expect(Number.isIntegerOrIntegerObject("hi")).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(null)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(undefined)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(true)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(false)).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(Symbol("12"))).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(Symbol())).toBe(false);
+    expect(Number.isIntegerOrIntegerObject({})).toBe(false);
+    expect(Number.isIntegerOrIntegerObject([])).toBe(false);
+    expect(Number.isIntegerOrIntegerObject([12])).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(new Set([12]))).toBe(false);
+    expect(Number.isIntegerOrIntegerObject(new Map([[12, 34]]))).toBe(false);
+  });
+
+  it("handles negative zero", () => {
+    expect(Number.isIntegerOrIntegerObject(-0)).toBe(true);
+    expect(Number.isIntegerOrIntegerObject(new Number(-0))).toBe(true);
+  });
+});

--- a/tools/adventure-pack/src/__tests__/numberPrototypeDigits.test.ts
+++ b/tools/adventure-pack/src/__tests__/numberPrototypeDigits.test.ts
@@ -75,4 +75,8 @@ describe("Number.prototype.digits", () => {
     expect(() => n.digits(42)).not.toThrow();
     expect(() => n.digits(1337)).not.toThrow();
   });
+
+  it("accepts Number objects", () => {
+    expect([...new Number(42).digits()]).toEqual([2, 4]);
+  });
 });

--- a/tools/adventure-pack/src/numberIsIntegerOrIntegerObject.ts
+++ b/tools/adventure-pack/src/numberIsIntegerOrIntegerObject.ts
@@ -1,0 +1,16 @@
+declare global {
+  interface NumberConstructor {
+    isIntegerOrIntegerObject(num: unknown): boolean;
+  }
+}
+
+Number.isIntegerOrIntegerObject = function (num: unknown): boolean {
+  return (
+    (typeof num === "number" || num instanceof Number) &&
+    Number.isInteger(Number(num))
+  );
+};
+
+// Needed to fix the error "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations. ts(2669)"
+// See: https://stackoverflow.com/questions/57132428/augmentations-for-the-global-scope-can-only-be-directly-nested-in-external-modul
+export {};

--- a/tools/adventure-pack/src/numberPrototypeDigits.ts
+++ b/tools/adventure-pack/src/numberPrototypeDigits.ts
@@ -1,3 +1,5 @@
+import "./numberIsIntegerOrIntegerObject";
+
 declare global {
   interface Number {
     digits(): Generator<number, void, undefined>;
@@ -6,26 +8,21 @@ declare global {
 }
 
 Number.prototype.digits = function (
-  this: number,
+  this: Number,
   radix: number = 10,
 ): Generator<number, void, undefined> {
-  // The Number cast is necessary for this check to work on LeetCode.
-  if (!(Number.isInteger(Number(this)) && this >= 0)) {
+  if (!(Number.isIntegerOrIntegerObject(this) && Number(this) >= 0)) {
     throw new Error("Must invoke on a non-negative integer.");
   }
-  if (!(Number.isInteger(radix) && radix >= 2)) {
+  if (!(Number.isIntegerOrIntegerObject(radix) && radix >= 2)) {
     throw new Error("Radix must be an integer >= 2.");
   }
 
-  return function* (this: number) {
-    let num = this;
+  return function* (this: Number) {
+    let num = Number(this);
     do {
       yield num % radix;
       num = Math.floor(num / radix);
     } while (num > 0);
   }.call(this);
 };
-
-// Needed to fix the error "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations. ts(2669)"
-// See: https://stackoverflow.com/questions/57132428/augmentations-for-the-global-scope-can-only-be-directly-nested-in-external-modul
-export {};


### PR DESCRIPTION
I get the sense that we will need to accept integers and integer objects intechangeably in more places, so making a utility for it. The existing `Number.isInteger` returns false on objects that are integers, e.g. `new Number(5)`.
