### PR TITLE
Add a `String.prototype.ord` and a `Number.prototype.chr` to the adventure pack

### DIFF
--- a/tools/adventure-pack/src/__tests__/stringPrototypeOrd.test.ts
+++ b/tools/adventure-pack/src/__tests__/stringPrototypeOrd.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "@jest/globals";
+
+import "../stringPrototypeOrd";
+
+describe("String.prototype.ord", () => {
+  it("gets the ASCII code of basic ASCII characters", () => {
+    expect("A".ord()).toBe(65);
+    expect("a".ord()).toBe(97);
+    expect("m".ord()).toBe(109);
+    expect("\n".ord()).toBe(10);
+    expect("=".ord()).toBe(61);
+    expect("~".ord()).toBe(126);
+    expect(" ".ord()).toBe(32);
+    expect("0".ord()).toBe(48);
+  });
+
+  it("looks at the first character of multi-character strings", () => {
+    expect("hi".ord()).toBe(104);
+    expect(" ?!".ord()).toBe(32);
+  });
+
+  it("handles empty string", () => {
+    expect("".ord()).toBe(undefined);
+  });
+
+  it("handles emoji", () => {
+    expect("🤪".ord()).toBe(0x1f92a);
+    expect("🤖".ord()).toBe(0x1f916);
+    expect("🦄".ord()).toBe(0x1f984);
+  });
+});

--- a/tools/adventure-pack/src/numberPrototypeChr.ts
+++ b/tools/adventure-pack/src/numberPrototypeChr.ts
@@ -1,0 +1,13 @@
+declare global {
+  interface Number {
+    chr(): string;
+  }
+}
+
+Number.prototype.chr = function (this: Number): string {
+  return String.fromCodePoint(Number(this));
+};
+
+// Needed to fix the error "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations. ts(2669)"
+// See: https://stackoverflow.com/questions/57132428/augmentations-for-the-global-scope-can-only-be-directly-nested-in-external-modul
+export {};

--- a/tools/adventure-pack/src/stringPrototypeOrd.ts
+++ b/tools/adventure-pack/src/stringPrototypeOrd.ts
@@ -1,0 +1,13 @@
+declare global {
+  interface String {
+    ord(): number | undefined;
+  }
+}
+
+String.prototype.ord = function (this: String): number | undefined {
+  return this.codePointAt(0);
+};
+
+// Needed to fix the error "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations. ts(2669)"
+// See: https://stackoverflow.com/questions/57132428/augmentations-for-the-global-scope-can-only-be-directly-nested-in-external-modul
+export {};


### PR DESCRIPTION
The `ord` and `chr` functions exist in a few languages, for example Ruby, Perl, and Python.
