### PR TITLE
Add an `Iterator.prototype.toIterable` to the adventure pack

### DIFF
--- a/tools/adventure-pack/src/functionReturnThis.ts
+++ b/tools/adventure-pack/src/functionReturnThis.ts
@@ -1,0 +1,13 @@
+declare global {
+  interface FunctionConstructor {
+    returnThis<T>(this: T): T;
+  }
+}
+
+Function.returnThis = function <T>(this: T): T {
+  return this;
+};
+
+// Needed to fix the error "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations. ts(2669)"
+// See: https://stackoverflow.com/questions/57132428/augmentations-for-the-global-scope-can-only-be-directly-nested-in-external-modul
+export {};

--- a/tools/adventure-pack/src/iteratorPrototypeFilter.ts
+++ b/tools/adventure-pack/src/iteratorPrototypeFilter.ts
@@ -1,20 +1,21 @@
+import "./iteratorPrototypeToIterable";
+
 import { iteratorPrototype } from "./iteratorPrototype";
-import { iteratorToIterable } from "./iteratorToIterable";
 
 declare global {
   interface Iterator<T> {
     filter(
       callbackfn: (value: T, index: number) => unknown,
-    ): Generator<T, void, undefined>;
+    ): Generator<T, void, void>;
   }
 }
 
 iteratorPrototype.filter ??= function* <T>(
   this: Iterator<T>,
   callbackFn: (element: T, index: number) => unknown,
-) {
+): Generator<T, void, void> {
   let index = 0;
-  for (const element of iteratorToIterable(this)) {
+  for (const element of this.toIterable()) {
     if (callbackFn(element, index)) {
       yield element;
     }

--- a/tools/adventure-pack/src/iteratorPrototypeMap.ts
+++ b/tools/adventure-pack/src/iteratorPrototypeMap.ts
@@ -1,20 +1,21 @@
+import "./iteratorPrototypeToIterable";
+
 import { iteratorPrototype } from "./iteratorPrototype";
-import { iteratorToIterable } from "./iteratorToIterable";
 
 declare global {
   interface Iterator<T> {
     map<TOut>(
       callbackFn: (element: T, index: number) => TOut,
-    ): Generator<TOut, void, undefined>;
+    ): Generator<TOut, void, void>;
   }
 }
 
-iteratorPrototype.map ??= function* <TIn, TOut>(
+iteratorPrototype.map = function* <TIn, TOut>(
   this: Iterator<TIn>,
   callbackFn: (element: TIn, index: number) => TOut,
-): Generator<TOut, void, undefined> {
+): Generator<TOut, void, void> {
   let index = 0;
-  for (const element of iteratorToIterable(this)) {
+  for (const element of this.toIterable()) {
     yield callbackFn(element, index);
     ++index;
   }

--- a/tools/adventure-pack/src/iteratorPrototypeToIterable.ts
+++ b/tools/adventure-pack/src/iteratorPrototypeToIterable.ts
@@ -1,0 +1,17 @@
+import "./functionReturnThis";
+
+import { iteratorPrototype } from "./iteratorPrototype";
+
+declare global {
+  interface Iterator<T> {
+    toIterable(): IterableIterator<T>;
+  }
+}
+
+iteratorPrototype.toIterable = function <T>(
+  this: Iterator<T>,
+): IterableIterator<T> {
+  (this as unknown as Record<string | symbol, unknown>)[Symbol.iterator] ??=
+    Function.returnThis;
+  return this as unknown as IterableIterator<T>;
+};

--- a/tools/adventure-pack/src/iteratorToIterable.ts
+++ b/tools/adventure-pack/src/iteratorToIterable.ts
@@ -1,6 +1,0 @@
-export function iteratorToIterable<T>(iterator: Iterator<T>): Iterable<T> {
-  if (Object.hasOwn(iterator, Symbol.iterator)) {
-    return iterator as unknown as Iterable<T>;
-  }
-  return { [Symbol.iterator]: () => iterator };
-}


### PR DESCRIPTION
I think this will be a little nicer than the `iteratorToIterable` function given our current philosophy of just adding more methods to core libraries!
