### PR TITLE
Read, rather than importing secrets

### DIFF
--- a/tools/download-submissions/package.json
+++ b/tools/download-submissions/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@code-chronicles/leetcode-api": "0.0.1",
     "nullthrows": "1.1.1",
-    "ts-node": "10.9.2"
+    "ts-node": "10.9.2",
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@code-chronicles/eslint-config": "0.0.1",

--- a/tools/download-submissions/src/main.ts
+++ b/tools/download-submissions/src/main.ts
@@ -12,9 +12,8 @@ import {
 // TODO: Make into a shared utility?
 import { sleep } from "@code-chronicles/leetcode-api/src/sleep";
 
-import secrets from "../secrets_DO_NOT_COMMIT_OR_SHARE.json";
-
 import { LANGUAGE_TO_FILE_EXTENSION } from "./constants";
+import { readSecrets } from "./readSecrets";
 
 type TransformedSubmission = Omit<
   Submission,
@@ -120,6 +119,9 @@ function getDirnameForSubmission(submission: TransformedSubmission): string {
 }
 
 async function main(): Promise<void> {
+  // TODO: maybe create the file from a template if it doesn't exist
+  const { leetcodeSessionCookie } = await readSecrets();
+
   const submissionsMap = new Map<string, TransformedSubmission>();
 
   const priorSubmissionsMap: Map<string, TransformedSubmission> =
@@ -193,7 +195,7 @@ async function main(): Promise<void> {
         console.error("Fetching...");
         // eslint-disable-next-line no-await-in-loop
         data = await getSubmissionList({
-          session: secrets.leetcodeSessionCookie,
+          session: leetcodeSessionCookie,
           // TODO: Don't hardcode the 20, export the constant from the API library.
           page: Math.floor(submissionsMap.size / 20),
         });

--- a/tools/download-submissions/src/readSecrets.ts
+++ b/tools/download-submissions/src/readSecrets.ts
@@ -1,0 +1,16 @@
+import fsPromises from "node:fs/promises";
+import { z } from "zod";
+
+const SECRETS_FILE = "secrets_DO_NOT_COMMIT_OR_SHARE.json";
+
+const secretsParser = z.object({
+  leetcodeSessionCookie: z.string().min(1),
+});
+
+export type Secrets = z.infer<typeof secretsParser>;
+
+export async function readSecrets(): Promise<Secrets> {
+  return secretsParser.parse(
+    JSON.parse(await fsPromises.readFile(SECRETS_FILE, "utf8")),
+  );
+}

--- a/tools/post-potd/package.json
+++ b/tools/post-potd/package.json
@@ -18,7 +18,8 @@
     "discord.js": "14.15.3",
     "invariant": "2.2.4",
     "nullthrows": "1.1.1",
-    "ts-node": "10.9.2"
+    "ts-node": "10.9.2",
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@code-chronicles/eslint-config": "0.0.1",

--- a/tools/post-potd/src/readSecrets.ts
+++ b/tools/post-potd/src/readSecrets.ts
@@ -1,0 +1,17 @@
+import fsPromises from "node:fs/promises";
+import { z } from "zod";
+
+const SECRETS_FILE = "secrets_DO_NOT_COMMIT_OR_SHARE.json";
+
+const secretsParser = z.object({
+  discordChannelID: z.string().regex(/^\d+$/),
+  discordToken: z.string().min(1),
+});
+
+export type Secrets = z.infer<typeof secretsParser>;
+
+export async function readSecrets(): Promise<Secrets> {
+  return secretsParser.parse(
+    JSON.parse(await fsPromises.readFile(SECRETS_FILE, "utf8")),
+  );
+}

--- a/tools/post-potd/src/sendDiscordMessage.ts
+++ b/tools/post-potd/src/sendDiscordMessage.ts
@@ -1,0 +1,26 @@
+import { ChannelType, Client, GatewayIntentBits } from "discord.js";
+import invariant from "invariant";
+
+import type { Secrets } from "./readSecrets";
+
+export async function sendDiscordMessage(
+  { discordChannelID, discordToken }: Secrets,
+  content: string,
+): Promise<void> {
+  const client = new Client({ intents: [GatewayIntentBits.Guilds] });
+
+  try {
+    await client.login(discordToken);
+
+    const channel = await client.channels.fetch(discordChannelID);
+    invariant(
+      channel?.type === ChannelType.GuildText,
+      "Channel must be a text channel!",
+    );
+
+    const message = await channel.send(content);
+    await message.suppressEmbeds(true);
+  } finally {
+    await client.destroy();
+  }
+}


### PR DESCRIPTION
This avoids the risk of some build tool packaging the secrets into a file to distribute. It also fixes the issue with a clean checkout of the repository not passing `yarn typecheck`.