### PR TITLE
Add an `Iterator.prototype.max` and an `Iterator.prototype.min` to the adventure pack

### DIFF
--- a/tools/adventure-pack/src/__tests__/iteratorPrototypeMax.test.ts
+++ b/tools/adventure-pack/src/__tests__/iteratorPrototypeMax.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "@jest/globals";
+
+import "../iteratorPrototypeMax";
+
+describe("Iterator.prototype.max", () => {
+  it("can find the max of an iterator of numbers", () => {
+    expect([1, 2, 3].values().max()).toBe(3);
+    expect([1, 12, 5.3, 1.37].values().max()).toBe(12);
+    expect([42, 0, 1337].values().max()).toBe(1337);
+    expect([5, 1e100, Infinity, 7, 0, -3, -Infinity].values().max()).toBe(
+      Infinity,
+    );
+  });
+
+  it("can find the max of an iterator of strings", () => {
+    expect(["apple", "banana", "orange", "kiwi", ""].values().max()).toBe(
+      "orange",
+    );
+    expect([..."supercalifragilistic"].values().max()).toBe("u");
+  });
+
+  it("can find the max of an iterator of bigints", () => {
+    expect([1n, 2n, 3n].values().max()).toBe(3n);
+    expect([1n, 12n, 5n, -70n].values().max()).toBe(12n);
+    expect([42n, 0n, 1337n].values().max()).toBe(1337n);
+    expect([5n, 2n ** 100n, 10n ** 100n].values().max()).toBe(10n ** 100n);
+  });
+
+  it("can handle exclusively negative numbers", () => {
+    expect([-78.7, -100, -78.4, -85.2].values().max()).toBe(-78.4);
+    expect([-100n, -78n, -85n].values().max()).toBe(-78n);
+  });
+
+  it("returns undefined for an empty iterator", () => {
+    expect([].values().max()).toBe(undefined);
+    expect(new Set().values().max()).toBe(undefined);
+    expect(new Map().values().max()).toBe(undefined);
+    expect((function* () {})().max()).toBe(undefined);
+  });
+
+  it("throws if the iterator has mixed types", () => {
+    expect(() => [5n, 5].values().max()).toThrow();
+    expect(() => ["apple", 47, null, new Set()].values().max()).toThrow();
+    expect(() => [{}, new Map(), Symbol("wat")].values().max()).toThrow();
+  });
+
+  it("throws if the iterator has incomparable types", () => {
+    expect(() => [Symbol("foo"), Symbol("bar")].values().max()).toThrow();
+    expect(() => [new Set([1, 2, 3]), new Set()].values().max()).toThrow();
+  });
+
+  it("doesn't throw if the iterator only has one element, even if the type is incomparable", () => {
+    expect([new Set([1, 2, 3])].values().max()).toEqual(new Set([1, 2, 3]));
+    expect([new Map([["hello", "goodbye"]])].values().max()).toEqual(
+      new Map([["hello", "goodbye"]]),
+    );
+  });
+
+  it("returns the same reference as the iterator", () => {
+    const obj = {};
+    expect([obj].values().max()).toBe(obj);
+
+    const symbol = Symbol("foo");
+    expect([symbol].values().max()).toBe(symbol);
+  });
+
+  it("tries to ignore NaN", () => {
+    expect([1, NaN, 2, 3].values().max()).toBe(3);
+    expect([NaN, 1, 2, 3].values().max()).toBe(3);
+    expect([NaN, 1, NaN, 2, NaN, 3, NaN].values().max()).toBe(3);
+    expect([NaN, NaN, NaN, NaN].values().max()).toBe(NaN);
+    expect([NaN].values().max()).toBe(NaN);
+  });
+
+  it("still throws if NaN is present in a non-numeric iterator", () => {
+    expect(() => ["hello", NaN].values().max()).toThrow();
+    expect(() => [NaN, "hello"].values().max()).toThrow();
+    expect(() => [5n, NaN].values().max()).toThrow();
+    expect(() => [NaN, 2n].values().max()).toThrow();
+    expect(() => [new Set(), NaN].values().max()).toThrow();
+    expect(() => [NaN, new Set()].values().max()).toThrow();
+  });
+});

--- a/tools/adventure-pack/src/__tests__/iteratorPrototypeMin.test.ts
+++ b/tools/adventure-pack/src/__tests__/iteratorPrototypeMin.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "@jest/globals";
+
+import "../iteratorPrototypeMin";
+
+describe("Iterator.prototype.min", () => {
+  it("can find the min of an iterator of numbers", () => {
+    expect([1, 2, 3].values().min()).toBe(1);
+    expect([100, 12, 5.3, 1.37].values().min()).toBe(1.37);
+    expect([42, 0, 1337].values().min()).toBe(0);
+    expect([5, 1e100, Infinity, 7, 0, -3, -Infinity].values().min()).toBe(
+      -Infinity,
+    );
+  });
+
+  it("can find the min of an iterator of strings", () => {
+    expect(["apple", "banana", "orange", "kiwi", ""].values().min()).toBe("");
+    expect(["apple", "banana", "orange", "kiwi"].values().min()).toBe("apple");
+    expect([..."supercalifragilistic"].values().min()).toBe("a");
+  });
+
+  it("can find the min of an iterator of bigints", () => {
+    expect([1n, 2n, 3n].values().min()).toBe(1n);
+    expect([100n, 12n, -70n, 5n].values().min()).toBe(-70n);
+    expect([42n, 0n, 1337n].values().min()).toBe(0n);
+    expect([2n ** 100n, 10n ** 100n, 5n].values().min()).toBe(5n);
+  });
+
+  it("can handle exclusively negative numbers", () => {
+    expect([-78.7, -100, -78.4, -85.2].values().min()).toBe(-100);
+    expect([-79n, -100n, -78n, -85n].values().min()).toBe(-100n);
+  });
+
+  it("returns undefined for an empty iterator", () => {
+    expect([].values().min()).toBe(undefined);
+    expect(new Set().values().min()).toBe(undefined);
+    expect(new Map().values().min()).toBe(undefined);
+    expect((function* () {})().min()).toBe(undefined);
+  });
+
+  it("throws if the iterator has mixed types", () => {
+    expect(() => [5n, 5].values().min()).toThrow();
+    expect(() => ["apple", 47, null, new Set()].values().min()).toThrow();
+    expect(() => [{}, new Map(), Symbol("wat")].values().min()).toThrow();
+  });
+
+  it("throws if the iterator has incomparable types", () => {
+    expect(() => [Symbol("foo"), Symbol("bar")].values().min()).toThrow();
+    expect(() => [new Set([1, 2, 3]), new Set()].values().min()).toThrow();
+  });
+
+  it("doesn't throw if the iterator only has one element, even if the type is incomparable", () => {
+    expect([new Set([1, 2, 3])].values().min()).toEqual(new Set([1, 2, 3]));
+    expect([new Map([["hello", "goodbye"]])].values().min()).toEqual(
+      new Map([["hello", "goodbye"]]),
+    );
+  });
+
+  it("returns the same reference as the iterator", () => {
+    const obj = {};
+    expect([obj].values().min()).toBe(obj);
+
+    const symbol = Symbol("foo");
+    expect([symbol].values().min()).toBe(symbol);
+  });
+
+  it("tries to ignore NaN", () => {
+    expect([1, NaN, 2, 3].values().min()).toBe(1);
+    expect([NaN, 1, 2, 3].values().min()).toBe(1);
+    expect([NaN, 1, NaN, 2, NaN, 3, NaN].values().min()).toBe(1);
+    expect([NaN, NaN, NaN, NaN].values().min()).toBe(NaN);
+    expect([NaN].values().min()).toBe(NaN);
+  });
+
+  it("still throws if NaN is present in a non-numeric iterator", () => {
+    expect(() => ["hello", NaN].values().min()).toThrow();
+    expect(() => [NaN, "hello"].values().min()).toThrow();
+    expect(() => [5n, NaN].values().min()).toThrow();
+    expect(() => [NaN, 2n].values().min()).toThrow();
+    expect(() => [new Set(), NaN].values().min()).toThrow();
+    expect(() => [NaN, new Set()].values().min()).toThrow();
+  });
+});

--- a/tools/adventure-pack/src/iteratorPrototypeMax.ts
+++ b/tools/adventure-pack/src/iteratorPrototypeMax.ts
@@ -1,0 +1,41 @@
+/**
+ * @adventure
+ * {"name": "Iterator.prototype.max"}
+ */
+
+import "./iteratorPrototypeToIterable";
+
+import { iteratorPrototype } from "./iteratorPrototype";
+
+declare global {
+  interface Iterator<T> {
+    max(): T | undefined;
+  }
+}
+
+iteratorPrototype.max = function <T>(this: Iterator<T>): T | undefined {
+  const cmp = (a: unknown, b: unknown): number => {
+    if (
+      (typeof a === "string" && typeof b === "string") ||
+      (typeof a === "number" && typeof b === "number") ||
+      (typeof a === "bigint" && typeof b === "bigint")
+    ) {
+      return a < b ? -1 : a > b ? 1 : 0;
+    }
+    throw new Error("Comparing mismatched types!");
+  };
+
+  let res: T | undefined = undefined;
+  let isFirst = true;
+  for (const element of this.toIterable()) {
+    if (
+      isFirst ||
+      cmp(element, res) > 0 ||
+      (Number.isNaN(res) && !Number.isNaN(element))
+    ) {
+      res = element;
+      isFirst = false;
+    }
+  }
+  return res;
+};

--- a/tools/adventure-pack/src/iteratorPrototypeMin.ts
+++ b/tools/adventure-pack/src/iteratorPrototypeMin.ts
@@ -1,0 +1,41 @@
+/**
+ * @adventure
+ * {"name": "Iterator.prototype.min"}
+ */
+
+import "./iteratorPrototypeToIterable";
+
+import { iteratorPrototype } from "./iteratorPrototype";
+
+declare global {
+  interface Iterator<T> {
+    min(): T | undefined;
+  }
+}
+
+iteratorPrototype.min = function <T>(this: Iterator<T>): T | undefined {
+  const cmp = (a: unknown, b: unknown): number => {
+    if (
+      (typeof a === "string" && typeof b === "string") ||
+      (typeof a === "number" && typeof b === "number") ||
+      (typeof a === "bigint" && typeof b === "bigint")
+    ) {
+      return a < b ? -1 : a > b ? 1 : 0;
+    }
+    throw new Error("Comparing mismatched types!");
+  };
+
+  let res: T | undefined = undefined;
+  let isFirst = true;
+  for (const element of this.toIterable()) {
+    if (
+      isFirst ||
+      cmp(element, res) < 0 ||
+      (Number.isNaN(res) && !Number.isNaN(element))
+    ) {
+      res = element;
+      isFirst = false;
+    }
+  }
+  return res;
+};


### PR DESCRIPTION
Although spreading the iterator into `Math.max` or `Math.min` (e.g. `Math.max(...iterator)` could work for numeric types, this one will also work for strings and bigints. In a subsequent commit, we can add support for custom comparison as well!
