### PR TITLE
Get the Post PotD script data to update

### DIFF
--- a/.github/workflows/post-potd.yml
+++ b/.github/workflows/post-potd.yml
@@ -52,7 +52,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tools/post-potd/data.json
-          key: post-potd-script-data
+          restore-keys: post-potd-script-data-
+          # TODO: maybe label with the date instead of the run ID?
+          key: post-potd-script-data-${{ github.run_id }}
 
       - name: Post problem of the day
         run: (cd tools/post-potd && yarn start)


### PR DESCRIPTION
I didn't realize that caches are immutable, so once we write the script data to cache once, it never gets updated again. To work around this, we use a unique key per run, while using a shared `restore_keys` prefix, per https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
