### PR TITLE
Add GitHub action that posts a health report on each PR

### DIFF
--- a/.github/workflows/generate-health-report.js
+++ b/.github/workflows/generate-health-report.js
@@ -1,0 +1,68 @@
+const { exec: execWithCallback } = require("node:child_process");
+const { promisify } = require("node:util");
+
+const exec = promisify(execWithCallback);
+
+const GITHUB_ACTIONS_BOT_ID = 41898282;
+const HEALTH_REPORT_PREFIX = `<!-- HEALTH REPORT -->\n\n`;
+
+const COMMANDS = [
+  "(cd tools && yarn format && ! (git status --porcelain | grep .))",
+  "(cd tools && yarn lint)",
+  "(cd tools && yarn typecheck)",
+  "(cd tools && yarn test)",
+  "(cd tools/adventure-pack && yarn build-app)",
+];
+
+module.exports = async ({ context, github }) => {
+  const prNumber = context.payload.pull_request.number;
+
+  const existingHealthReport = await github.rest.issues
+    .listComments({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+    })
+    .then(({ data }) =>
+      data.find(
+        (c) =>
+          c.user.id === GITHUB_ACTIONS_BOT_ID &&
+          c.body.startsWith(HEALTH_REPORT_PREFIX),
+      ),
+    );
+
+  const lines = [];
+  for (const command of COMMANDS) {
+    console.log("Running: " + command);
+    try {
+      await exec(command);
+      lines.push(` * \`${command}\`: ✅`);
+    } catch (err) {
+      console.error(err);
+      lines.push(` * \`${command}\`: ❌`);
+    }
+  }
+
+  const healthReportBody =
+    HEALTH_REPORT_PREFIX +
+    "# PR Health Report\n\nLast checked commit " +
+    context.payload.pull_request.head.sha +
+    ".\n\n" +
+    lines.map((line) => line + "\n").join("");
+
+  if (existingHealthReport) {
+    await github.rest.issues.updateComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: existingHealthReport.id,
+      body: healthReportBody,
+    });
+  } else {
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+      body: healthReportBody,
+    });
+  }
+};

--- a/.github/workflows/generate-health-report.yml
+++ b/.github/workflows/generate-health-report.yml
@@ -1,0 +1,35 @@
+name: Generate PR Health Report
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# TODO: maybe cancel ongoing runs for this PR so there's not a race condition on posting the health report comment
+
+jobs:
+  generate-health-report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+          cache-dependency-path: tools/yarn.lock
+
+      - name: Install dependencies
+        run: (cd tools && yarn)
+
+      - name: Generate health report and post it on PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: require('.github/workflows/generate-health-report.js')({context, github})


### PR DESCRIPTION
It's a simple API, just a list of commands that need to run successfully in the repository.