### PR TITLE
Only run post PotD action an hour early

### DIFF
--- a/.github/workflows/post-potd.yml
+++ b/.github/workflows/post-potd.yml
@@ -2,14 +2,11 @@ name: Post LeetCode PotD to Discord
 
 on:
   schedule:
-    # A new problem of the day is posted at 00:00 UTC each day.
-    - cron: "0 0 * * *"
-
     # Scheduled GitHub Actions seem to be consistently delayed... So this is
-    # a bit of a hack to also kick off this workflow an hour early. If it
-    # runs before the new problem of the day is available, it will simply
-    # sleep until it is. And since we only post once per day thanks to the
-    # cache, this shouldn't result in any duplicate posts.
+    # a bit of a hack to kick off this workflow an hour early. If it runs
+    # before the new problem of the day is available, it will simply sleep
+    # until it is. And since we only post once per day thanks to the cache,
+    # this shouldn't result in any duplicate posts.
     - cron: "0 23 * * *"
 
   # Allows running this workflow manually from the Actions tab.


### PR DESCRIPTION
Currently, the action runs twice:
1. an hour before the new problem is expected to be posted (11pm UTC)
2. when the new problem is expected to be posted (midnight UTC)

The first of these is the one that is actually doing all the posting. It won't have a new problem ready when it first runs, but it will sleep until it does.

By the time the second of these runs, the new problem of the day has already been posted, and so we try sleeping for the rest of the day. The action then ends up getting canceled by GitHub for running too long (the limit appears to be 6 hours).

So let's get rid of the second run, since the early run is working well.
