### PR TITLE
Safer way to get `Iterator.prototype`

### DIFF
--- a/tools/adventure-pack/goodies/typescript/Iterator.prototype.toArray/index.test.ts
+++ b/tools/adventure-pack/goodies/typescript/Iterator.prototype.toArray/index.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
 
+import "../Iterator.prototype.filter";
+import "../Iterator.prototype.map";
+
 import "./index";
 
 describe("Iterator.prototype.toArray", () => {

--- a/tools/adventure-pack/goodies/typescript/Iterator.prototype/index.ts
+++ b/tools/adventure-pack/goodies/typescript/Iterator.prototype/index.ts
@@ -1,6 +1,3 @@
-import "../Object.getUnsafe";
-
-export const iteratorPrototype = Object.getUnsafe(globalThis, [
-  "Iterator",
-  "prototype",
-]) as Iterator<unknown, unknown, unknown>;
+export const iteratorPrototype = Object.getPrototypeOf(
+  Object.getPrototypeOf([].values()),
+) as Iterator<unknown, unknown, unknown>;


### PR DESCRIPTION
The expression `Iterator.protoype` doesn't work until Node 22, this will make it work with Node 20 as well, which is what LeetCode currently uses.
