### PR TITLE
Merge the AP class when merging Java code

### DIFF
--- a/tools/adventure-pack/src/app/GoodyCard.tsx
+++ b/tools/adventure-pack/src/app/GoodyCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import type { Goody } from "./Goody";
 import { HighlightedCode } from "./HighlightedCode";
+import { mergeJavaCode } from "./mergeJavaCode";
 
 function goodyToText(goody: Goody): string {
   switch (goody.language) {
@@ -9,14 +10,14 @@ function goodyToText(goody: Goody): string {
       return (
         `package ${goody.packageName};\n\n` +
         goody.importsCode +
-        goody.code
+        mergeJavaCode([goody])
       ).trim();
     }
     case "javascript": {
       return (
         goody.imports.map((im) => `import ${JSON.stringify(im)};\n`).join("") +
         "\n" +
-        +goody.code
+        goody.code
       ).trim();
     }
     case "python3": {

--- a/tools/adventure-pack/src/app/mergeJavaCode.ts
+++ b/tools/adventure-pack/src/app/mergeJavaCode.ts
@@ -1,0 +1,41 @@
+import invariant from "invariant";
+import type { ReadonlyDeep } from "type-fest";
+
+import type { JavaGoody } from "./parsers/javaGoodyParser";
+
+const ADVENTURE_PACK_CLASS_NAME = "AP";
+
+export function mergeJavaCode(goodies: Iterable<ReadonlyDeep<JavaGoody>>) {
+  const classes: Record<string, { code: string[]; modifiers: Set<string> }> =
+    {};
+  for (const goody of goodies) {
+    for (const className of Object.keys(goody.codeByClass)) {
+      invariant(
+        classes[className] == null || className === ADVENTURE_PACK_CLASS_NAME,
+        `Only the ${ADVENTURE_PACK_CLASS_NAME} class can exist in multiple goodies!`,
+      );
+
+      classes[className] ??= { modifiers: new Set(), code: [] };
+      for (const modifier of goody.codeByClass[className].modifiers) {
+        classes[className].modifiers.add(modifier);
+      }
+      classes[className].code.push(goody.codeByClass[className].code);
+    }
+  }
+
+  const adventurePackClass = classes[ADVENTURE_PACK_CLASS_NAME];
+  if (adventurePackClass != null) {
+    adventurePackClass.code.unshift(
+      `  private ${ADVENTURE_PACK_CLASS_NAME}() {}`,
+    );
+  }
+
+  const res: string[] = [];
+  for (const className of Object.keys(classes)) {
+    res.push(
+      `${[...classes[className].modifiers, "class", className].join(" ")} {\n${classes[className].code.map((section) => section + "\n").join("\n")}}`,
+    );
+  }
+
+  return res.join("\n\n");
+}

--- a/tools/adventure-pack/src/app/parsers/goodyBaseParser.ts
+++ b/tools/adventure-pack/src/app/parsers/goodyBaseParser.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { nonBlankStringParser } from "./nonBlankStringParser";
 
 export const goodyBaseParser = z.object({
-  code: nonBlankStringParser,
   imports: z.array(nonBlankStringParser),
   importedBy: z.array(nonBlankStringParser),
   name: nonBlankStringParser,

--- a/tools/adventure-pack/src/app/parsers/javaGoodyParser.ts
+++ b/tools/adventure-pack/src/app/parsers/javaGoodyParser.ts
@@ -1,15 +1,27 @@
 import { z } from "zod";
 
 import { goodyBaseParser } from "./goodyBaseParser";
+import { nonBlankStringParser } from "./nonBlankStringParser";
 
-export const javaGoodyParser = goodyBaseParser.extend({
-  language: z.literal("java"),
-  packageName: z
-    .string()
-    .regex(/^[a-z0-9_]+$/)
-    .regex(/^[^_]/)
-    .regex(/[^_]$/),
-  importsCode: z.string(),
-});
+export const javaGoodyParser = goodyBaseParser
+  .extend({
+    codeByClass: z.record(
+      nonBlankStringParser,
+      z
+        .object({
+          modifiers: z.array(nonBlankStringParser),
+          code: z.string(),
+        })
+        .strict(),
+    ),
+    language: z.literal("java"),
+    packageName: z
+      .string()
+      .regex(/^[a-z0-9_]+$/)
+      .regex(/^[^_]/)
+      .regex(/[^_]$/),
+    importsCode: z.string(),
+  })
+  .strict();
 
 export type JavaGoody = z.infer<typeof javaGoodyParser>;

--- a/tools/adventure-pack/src/app/parsers/javaScriptGoodyParser.ts
+++ b/tools/adventure-pack/src/app/parsers/javaScriptGoodyParser.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
 import { goodyBaseParser } from "./goodyBaseParser";
+import { nonBlankStringParser } from "./nonBlankStringParser";
 
 export const javaScriptGoodyParser = goodyBaseParser.extend({
+  code: nonBlankStringParser,
   language: z.literal("javascript"),
 });
 

--- a/tools/adventure-pack/src/app/parsers/python3GoodyParser.ts
+++ b/tools/adventure-pack/src/app/parsers/python3GoodyParser.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
 import { goodyBaseParser } from "./goodyBaseParser";
+import { nonBlankStringParser } from "./nonBlankStringParser";
 
 export const python3GoodyParser = goodyBaseParser.extend({
+  code: nonBlankStringParser,
   language: z.literal("python3"),
 });
 

--- a/tools/adventure-pack/src/app/parsers/typeScriptGoodyParser.ts
+++ b/tools/adventure-pack/src/app/parsers/typeScriptGoodyParser.ts
@@ -4,6 +4,7 @@ import { goodyBaseParser } from "./goodyBaseParser";
 import { nonBlankStringParser } from "./nonBlankStringParser";
 
 export const typeScriptGoodyParser = goodyBaseParser.extend({
+  code: nonBlankStringParser,
   // TODO: generalize to simply declarations
   globalModuleDeclarations: z.array(nonBlankStringParser),
   language: z.literal("typescript"),

--- a/tools/adventure-pack/src/scripts/package-goodies/java/constants.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/constants.ts
@@ -1,0 +1,3 @@
+import path from "node:path";
+
+export const GOODIES_DIRECTORY = path.join("goodies", "java", "src");

--- a/tools/adventure-pack/src/scripts/package-goodies/java/extractImports.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/extractImports.ts
@@ -1,0 +1,47 @@
+import { getLines, isStringEmptyOrWhitespaceOnly } from "@code-chronicles/util";
+
+export function extractImports(code: string): {
+  codeWithoutImports: string;
+  imports: Set<string>;
+  importsCode: string;
+} {
+  const lines = Array.from(getLines(code));
+  const imports = new Set<string>();
+  const importsCode: string[] = [];
+
+  while (lines.length > 0) {
+    if (isStringEmptyOrWhitespaceOnly(lines[0])) {
+      importsCode.push(lines.shift()!);
+      continue;
+    }
+
+    const packageNameMatch = lines[0].match(/^package\s+[^;]+;\n?$/);
+    if (packageNameMatch != null) {
+      // TODO: verify that the package name matches what's expected
+      lines.shift();
+      continue;
+    }
+
+    const importMatch = lines[0].match(/^import\s+(?:static\s+)?([^\.]+)\./);
+    if (importMatch != null) {
+      importsCode.push(lines.shift()!);
+      imports.add(importMatch[1]);
+      continue;
+    }
+
+    break;
+  }
+
+  while (
+    importsCode.length > 0 &&
+    isStringEmptyOrWhitespaceOnly(importsCode[0])
+  ) {
+    importsCode.shift();
+  }
+
+  return {
+    codeWithoutImports: lines.join(""),
+    imports,
+    importsCode: importsCode.join(""),
+  };
+}

--- a/tools/adventure-pack/src/scripts/package-goodies/java/readCode.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/readCode.ts
@@ -1,0 +1,27 @@
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+
+import { only } from "@code-chronicles/util";
+
+import { GOODIES_DIRECTORY } from "./constants";
+
+export async function readCode(packageName: string): Promise<string> {
+  const fileEntries = await fsPromises.readdir(
+    path.join(GOODIES_DIRECTORY, packageName),
+    { withFileTypes: true },
+  );
+
+  const mainFileName = only(
+    fileEntries.filter(
+      (entry) =>
+        entry.isFile() &&
+        entry.name.endsWith(".java") &&
+        entry.name !== "Test.java",
+    ),
+  ).name;
+
+  return await fsPromises.readFile(
+    path.join(GOODIES_DIRECTORY, packageName, mainFileName),
+    "utf8",
+  );
+}

--- a/tools/adventure-pack/src/scripts/package-goodies/java/readGoodies.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/readGoodies.ts
@@ -2,7 +2,8 @@ import invariant from "invariant";
 import fsPromises from "node:fs/promises";
 
 import type { JavaGoody } from "../../../app/parsers/javaGoodyParser";
-import { readBasicGoody, GOODIES_DIRECTORY } from "./readBasicGoody";
+import { GOODIES_DIRECTORY } from "./constants";
+import { readBasicGoody } from "./readBasicGoody";
 
 export async function readGoodies(): Promise<Record<string, JavaGoody>> {
   const fileEntries = await fsPromises.readdir(GOODIES_DIRECTORY, {
@@ -59,12 +60,16 @@ export async function readGoodies(): Promise<Record<string, JavaGoody>> {
     });
   }
 
+  // TODO: assert that the AP class is the only one that exists in multiple goodies
+
+  // TODO: reuse this code across languages
   for (const goody of Object.values(goodiesByName)) {
     for (const im of goody.imports) {
       goodiesByName[im].importedBy.push(goody.name);
     }
   }
 
+  // TODO: sort imports case-insensitively
   for (const goody of Object.values(goodiesByName)) {
     goody.importedBy.sort();
     goody.imports.sort();

--- a/tools/adventure-pack/src/scripts/package-goodies/java/readMetadata.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/readMetadata.ts
@@ -1,0 +1,22 @@
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+
+import { GOODIES_DIRECTORY } from "./constants";
+
+const metadataParser = z
+  .object({
+    name: z.string().regex(/^\S/).regex(/\S$/),
+  })
+  .strict();
+
+type Metadata = z.infer<typeof metadataParser>;
+
+export async function readMetadata(packageName: string): Promise<Metadata> {
+  const text = await fsPromises.readFile(
+    path.join(GOODIES_DIRECTORY, packageName, "goody.json"),
+    "utf8",
+  );
+
+  return metadataParser.parse(JSON.parse(text));
+}

--- a/tools/util/src/index.ts
+++ b/tools/util/src/index.ts
@@ -3,6 +3,7 @@ export { getLines } from "./getLines";
 export { getMultilineCommentText } from "./getMultilineCommentText";
 export { getRandomBytes } from "./getRandomBytes";
 export { isStringEmptyOrWhitespaceOnly } from "./isStringEmptyOrWhitespaceOnly";
+export { mapObjectValues } from "./mapObjectValues";
 export { objectFromKeys } from "./objectFromKeys";
 export { only } from "./only";
 export { promiseIdleCallback } from "./promiseIdleCallback";

--- a/tools/util/src/mapObjectValues.ts
+++ b/tools/util/src/mapObjectValues.ts
@@ -1,0 +1,16 @@
+export function mapObjectValues<
+  TKey extends string | number | symbol,
+  TVal,
+  TOut,
+>(
+  obj: Readonly<Record<TKey, TVal>>,
+  mapFn: (value: TVal, key: TKey) => TOut,
+): Record<TKey, TOut> {
+  const res = {} as Record<TKey, TOut>;
+
+  for (const [key, val] of Object.entries(obj) as [TKey, TVal][]) {
+    res[key] = mapFn(val, key);
+  }
+
+  return res;
+}


### PR DESCRIPTION
Java requires that all functions exist within a class. AP (short form of Adventure Pack) is intended to be the class that houses all of the helper functions that don't have a better place to be defined. We should merge its contents when merging Java goodies.

Fixes #126.
