### PR TITLE
Update export handling in TypeScript code merging and rendering

### DIFF
--- a/tools/adventure-pack/goodies/typescript/Array.prototype.slidingWindows/index.ts
+++ b/tools/adventure-pack/goodies/typescript/Array.prototype.slidingWindows/index.ts
@@ -24,7 +24,7 @@ class ArraySlice<T> {
 
   [Symbol.iterator] = function* (
     this: ArraySlice<T>,
-  ): Generator<T, void, undefined> {
+  ): Generator<T, void, void> {
     for (let i = this.start; i <= this.end; ++i) {
       yield this.array[i];
     }
@@ -101,7 +101,7 @@ declare global {
 Array.prototype.slidingWindows = function* <T>(
   this: ReadonlyArray<T>,
   windowSize: number,
-): Generator<ArraySlice<T>, void, undefined> {
+): Generator<ArraySlice<T>, void, void> {
   for (
     let win: IndexableArraySlice<T> | null = ArraySlice.get(
       this,

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -202,7 +202,7 @@ Array.prototype.swap = function (i, j) {
   this[j] = tmp;
 };
 
-export class BinaryHeap {
+class BinaryHeap {
   compareFn;
   items = [];
 
@@ -460,7 +460,7 @@ exports[`App can equip single goody: JavaScript Iterator.prototype.max 1`] = `
 // Adventure Pack commit fake-commit-hash
 // Running at: https://example.com/
 
-export function compareNatural(a, b) {
+function compareNatural(a, b) {
   if (
     (typeof a === "number" && typeof b === "number") ||
     (typeof a === "string" && typeof b === "string") ||
@@ -525,7 +525,7 @@ exports[`App can equip single goody: JavaScript Iterator.prototype.min 1`] = `
 // Adventure Pack commit fake-commit-hash
 // Running at: https://example.com/
 
-export function compareNatural(a, b) {
+function compareNatural(a, b) {
   if (
     (typeof a === "number" && typeof b === "number") ||
     (typeof a === "string" && typeof b === "string") ||
@@ -801,7 +801,7 @@ exports[`App can equip single goody: JavaScript compareNatural 1`] = `
 // Adventure Pack commit fake-commit-hash
 // Running at: https://example.com/
 
-export function compareNatural(a, b) {
+function compareNatural(a, b) {
   if (
     (typeof a === "number" && typeof b === "number") ||
     (typeof a === "string" && typeof b === "string") ||
@@ -945,7 +945,7 @@ class ArraySlice<T> {
 
   [Symbol.iterator] = function* (
     this: ArraySlice<T>,
-  ): Generator<T, void, undefined> {
+  ): Generator<T, void, void> {
     for (let i = this.start; i <= this.end; ++i) {
       yield this.array[i];
     }
@@ -1006,7 +1006,7 @@ type IndexableArraySlice<T> = ArraySlice<T> & {
 Array.prototype.slidingWindows = function* <T>(
   this: ReadonlyArray<T>,
   windowSize: number,
-): Generator<ArraySlice<T>, void, undefined> {
+): Generator<ArraySlice<T>, void, void> {
   for (
     let win: IndexableArraySlice<T> | null = ArraySlice.get(
       this,
@@ -1060,7 +1060,7 @@ Array.prototype.swap = function <T>(this: T[], i: number, j: number): void {
   this[j] = tmp;
 };
 
-export class BinaryHeap<T> {
+class BinaryHeap<T> {
   private readonly items: T[] = [];
 
   constructor(private readonly compareFn: (a: T, b: T) => number) {}
@@ -1454,7 +1454,7 @@ declare global {
   }
 }
 
-export function compareNatural<T>(a: T, b: T): number {
+function compareNatural<T>(a: T, b: T): number {
   if (
     (typeof a === "number" && typeof b === "number") ||
     (typeof a === "string" && typeof b === "string") ||
@@ -1541,7 +1541,7 @@ declare global {
   }
 }
 
-export function compareNatural<T>(a: T, b: T): number {
+function compareNatural<T>(a: T, b: T): number {
   if (
     (typeof a === "number" && typeof b === "number") ||
     (typeof a === "string" && typeof b === "string") ||
@@ -1944,7 +1944,7 @@ exports[`App can equip single goody: TypeScript compareNatural 1`] = `
 // Adventure Pack commit fake-commit-hash
 // Running at: https://example.com/
 
-export function compareNatural<T>(a: T, b: T): number {
+function compareNatural<T>(a: T, b: T): number {
   if (
     (typeof a === "number" && typeof b === "number") ||
     (typeof a === "string" && typeof b === "string") ||

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -237,7 +237,7 @@ exports[`App can render goody: JavaScript Function.returnThis 1`] = `
 `;
 
 exports[`App can render goody: JavaScript Iterator.prototype 1`] = `
-"const iteratorPrototype = Object.getPrototypeOf(
+"export const iteratorPrototype = Object.getPrototypeOf(
   Object.getPrototypeOf([].values()),
 );"
 `;
@@ -598,7 +598,7 @@ class ArraySlice<T> {
 
   [Symbol.iterator] = function* (
     this: ArraySlice<T>,
-  ): Generator<T, void, undefined> {
+  ): Generator<T, void, void> {
     for (let i = this.start; i <= this.end; ++i) {
       yield this.array[i];
     }
@@ -659,7 +659,7 @@ type IndexableArraySlice<T> = ArraySlice<T> & {
 Array.prototype.slidingWindows = function* <T>(
   this: ReadonlyArray<T>,
   windowSize: number,
-): Generator<ArraySlice<T>, void, undefined> {
+): Generator<ArraySlice<T>, void, void> {
   for (
     let win: IndexableArraySlice<T> | null = ArraySlice.get(
       this,
@@ -775,7 +775,7 @@ Function.returnThis = function <T>(this: T): T {
 `;
 
 exports[`App can render goody: TypeScript Iterator.prototype 1`] = `
-"const iteratorPrototype = Object.getPrototypeOf(
+"export const iteratorPrototype = Object.getPrototypeOf(
   Object.getPrototypeOf([].values()),
 ) as Iterator<unknown, unknown, unknown>;"
 `;

--- a/tools/adventure-pack/src/app/mergeCode.ts
+++ b/tools/adventure-pack/src/app/mergeCode.ts
@@ -201,7 +201,7 @@ export async function mergeCode({
         "\n" +
         `// Adventure Pack commit ${commitHash}\n` +
         `// Running at: ${window.location.href}\n\n` +
-        mergedCode +
+        mergedCode.replaceAll(/^export\s+/gm, "") +
         "\n\n" +
         centerTextInComment({
           text: "END ADVENTURE PACK CODE",

--- a/tools/adventure-pack/src/scripts/package-goodies/typescript/readBaseGoody.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/typescript/readBaseGoody.ts
@@ -53,10 +53,6 @@ export async function readBaseGoody(
     }
   });
 
-  sourceFile.getVariableDeclarations().forEach((decl) => {
-    decl.getVariableStatementOrThrow().setIsExported(false);
-  });
-
   const updatedCode = await formatCode(sourceFile.getFullText());
 
   return {


### PR DESCRIPTION
When rendering an individual goody, let's keep the `export` keyword since it highlights the goody's effect. When merging goodies together, it's assumed that this will be included as-is into a bigger piece of code so let's remove the exports there.
