### PR TITLE
Remove uninitialized property declarations when transpiling to JavaScript

### DIFF
--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -104,9 +104,6 @@ exports[`App can equip single goody: JavaScript Array.prototype.slidingWindows 1
 // Running at: https://example.com/
 
 class ArraySlice {
-  array;
-  start;
-  end;
   constructor(array, start, end) {
     this.array = array;
     this.start = start;
@@ -203,7 +200,6 @@ Array.prototype.swap = function (i, j) {
 };
 
 class BinaryHeap {
-  compareFn;
   items = [];
 
   constructor(compareFn) {

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -74,9 +74,6 @@ final class AP {
 
 exports[`App can render goody: JavaScript Array.prototype.slidingWindows 1`] = `
 "class ArraySlice {
-  array;
-  start;
-  end;
   constructor(array, start, end) {
     this.array = array;
     this.start = start;
@@ -157,7 +154,6 @@ exports[`App can render goody: JavaScript BinaryHeap 1`] = `
 "import "Array.prototype.swap";
 
 export class BinaryHeap {
-  compareFn;
   items = [];
 
   constructor(compareFn) {

--- a/tools/adventure-pack/src/scripts/package-goodies/typescript/removeUninitializedPropertyDeclarations.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/typescript/removeUninitializedPropertyDeclarations.ts
@@ -1,0 +1,19 @@
+import { SyntaxKind } from "typescript";
+
+import { createSourceFile } from "./createSourceFile";
+import { removeNode } from "./removeNode";
+
+export function removeUninitializedPropertyDeclarations(code: string): string {
+  const sourceFile = createSourceFile(code);
+  sourceFile.getClasses().forEach((c) => {
+    c.getChildSyntaxListOrThrow()
+      .getChildrenOfKind(SyntaxKind.PropertyDeclaration)
+      .forEach((decl) => {
+        if (!decl.hasInitializer()) {
+          removeNode(decl);
+        }
+      });
+  });
+
+  return sourceFile.getFullText();
+}


### PR DESCRIPTION
These are an artifact of the transpilation process and are likely initialized in the constructor anyway. Let's save a few lines of output!
