### PR TITLE
Add a size property to BinaryHeap

### DIFF
--- a/tools/adventure-pack/goodies/typescript/BinaryHeap/index.ts
+++ b/tools/adventure-pack/goodies/typescript/BinaryHeap/index.ts
@@ -25,8 +25,12 @@ export class BinaryHeap<T> {
     return res;
   }
 
+  get size(): number {
+    return this.items.length;
+  }
+
   isEmpty(): boolean {
-    return this.items.length === 0;
+    return this.size === 0;
   }
 
   private static getParentIndex(index: number): number {

--- a/tools/adventure-pack/src/app/BinaryHeap.ts
+++ b/tools/adventure-pack/src/app/BinaryHeap.ts
@@ -1,6 +1,8 @@
 // TODO: split util by type of util so importing the main package doesn't pull in node:fs
 import { swap } from "@code-chronicles/util/src/swap";
 
+// TODO: find a way to keep the code in sync with the BinaryHeap goody
+
 export class BinaryHeap<T> {
   private readonly items: T[] = [];
 
@@ -26,8 +28,12 @@ export class BinaryHeap<T> {
     return res;
   }
 
+  get size(): number {
+    return this.items.length;
+  }
+
   isEmpty(): boolean {
-    return this.items.length === 0;
+    return this.size === 0;
   }
 
   private static getParentIndex(index: number): number {

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -230,8 +230,12 @@ class BinaryHeap {
     return res;
   }
 
+  get size() {
+    return this.items.length;
+  }
+
   isEmpty() {
-    return this.items.length === 0;
+    return this.size === 0;
   }
 
   static getParentIndex(index) {
@@ -1085,8 +1089,12 @@ class BinaryHeap<T> {
     return res;
   }
 
+  get size(): number {
+    return this.items.length;
+  }
+
   isEmpty(): boolean {
-    return this.items.length === 0;
+    return this.size === 0;
   }
 
   private static getParentIndex(index: number): number {

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -184,8 +184,12 @@ export class BinaryHeap {
     return res;
   }
 
+  get size() {
+    return this.items.length;
+  }
+
   isEmpty() {
-    return this.items.length === 0;
+    return this.size === 0;
   }
 
   static getParentIndex(index) {
@@ -716,8 +720,12 @@ export class BinaryHeap<T> {
     return res;
   }
 
+  get size(): number {
+    return this.items.length;
+  }
+
   isEmpty(): boolean {
-    return this.items.length === 0;
+    return this.size === 0;
   }
 
   private static getParentIndex(index: number): number {


### PR DESCRIPTION
Similar to the build-in `Map` and `Set`, this is accessed as a property (i.e. `heap.size`) rather than a method invocation (i.e. `heap.size()`).
