### PR TITLE
Differentiate Python 3 goody name from its module name

### DIFF
--- a/tools/adventure-pack/goodies/python3/src/int_digits/goody.json
+++ b/tools/adventure-pack/goodies/python3/src/int_digits/goody.json
@@ -1,0 +1,3 @@
+{
+  "name": "int.digits"
+}

--- a/tools/adventure-pack/package.json
+++ b/tools/adventure-pack/package.json
@@ -24,7 +24,7 @@
     "goodies:kotlin:format": "(cd goodies/kotlin && ./gradlew ktfmtCustom)",
     "goodies:kotlin:install": "javac -version",
     "goodies:kotlin:test": "(cd goodies/kotlin && ./gradlew test)",
-    "goodies:python3:format": "bash goodies/python3/format.sh",
+    "goodies:python3:format": "prettier --write goodies/python3 && bash goodies/python3/format.sh",
     "goodies:python3:install": "bash goodies/python3/install.sh",
     "goodies:python3:test": "bash goodies/python3/test.sh",
     "goodies:typescript:format": "prettier --write goodies/typescript",

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -867,7 +867,7 @@ fun lcm(a: Int, b: Int): Int = a / gcd(a, b) * b
 /////////////////////////// END ADVENTURE PACK CODE ////////////////////////////"
 `;
 
-exports[`App can equip single goody: Python 3 int_digits 1`] = `
+exports[`App can equip single goody: Python 3 int.digits 1`] = `
 "########################## BEGIN ADVENTURE PACK CODE ###########################
 # Adventure Pack commit fake-commit-hash
 # Running at: https://example.com/

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -530,7 +530,7 @@ import gcd_int_int.gcd
 fun lcm(a: Int, b: Int): Int = a / gcd(a, b) * b"
 `;
 
-exports[`App can render goody: Python 3 int_digits 1`] = `
+exports[`App can render goody: Python 3 int.digits 1`] = `
 "from typing import Generator
 
 

--- a/tools/adventure-pack/src/app/__tests__/equip-test.ts
+++ b/tools/adventure-pack/src/app/__tests__/equip-test.ts
@@ -17,7 +17,6 @@ function setUnsafe(
   (map as Record<string, unknown>)[properties.at(-1)!] = value;
 }
 
-setUnsafe(globalThis, ["requestIdleCallback"], <T>(fn: () => T): T => fn());
 setUnsafe(globalThis, ["window", "location", "href"], "https://example.com/");
 
 describe("App", () => {
@@ -27,8 +26,7 @@ describe("App", () => {
     for (const language of Object.keys(goodiesByLanguage) as Language[]) {
       const goodies = goodiesByLanguage[language];
       for (const goodyName of Object.keys(goodies)) {
-        // eslint-disable-next-line no-await-in-loop
-        const mergedCode = await mergeCode({
+        const mergedCode = mergeCode({
           commitHash: "fake-commit-hash",
           goodies,
           language,

--- a/tools/adventure-pack/src/scripts/package-goodies/java/readGoodies.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/readGoodies.ts
@@ -7,6 +7,7 @@ import type { JavaGoody } from "../../../app/parsers/javaGoodyParser";
 import { GOODIES_DIRECTORY } from "./constants";
 import { type JavaGoodyBase, readBaseGoody } from "./readBaseGoody";
 import { fillOutImportedByAndSortImports } from "../fillOutImportedByAndSortImports";
+import { normalizeGoodyNameToPackageOrModuleName } from "../normalizeGoodyNameToPackageOrModuleName";
 
 export async function readGoodies(): Promise<Record<string, JavaGoody>> {
   const fileEntries = await fsPromises.readdir(GOODIES_DIRECTORY, {
@@ -26,11 +27,9 @@ export async function readGoodies(): Promise<Record<string, JavaGoody>> {
     // eslint-disable-next-line no-await-in-loop
     const baseGoody = await readBaseGoody(packageName);
 
-    const expectedPackageName = baseGoody.name
-      .replace(/[A-Z]+/g, ([upper]) => "_" + upper.toLowerCase())
-      .replace(/[^a-z0-9]+/gi, "_")
-      .replace(/_$/, "")
-      .replace(/^_/, "");
+    const expectedPackageName = normalizeGoodyNameToPackageOrModuleName(
+      baseGoody.name,
+    );
     invariant(
       packageName === expectedPackageName,
       `Mismatched package name for goody! Expected ${JSON.stringify(expectedPackageName)} based on goody name ${JSON.stringify(baseGoody.name)} but got ${JSON.stringify(packageName)}.`,

--- a/tools/adventure-pack/src/scripts/package-goodies/kotlin/readGoodies.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/kotlin/readGoodies.ts
@@ -7,6 +7,7 @@ import type { KotlinGoody } from "../../../app/parsers/kotlinGoodyParser";
 import { GOODIES_DIRECTORY } from "./constants";
 import { type KotlinGoodyBase, readBaseGoody } from "./readBaseGoody";
 import { fillOutImportedByAndSortImports } from "../fillOutImportedByAndSortImports";
+import { normalizeGoodyNameToPackageOrModuleName } from "../normalizeGoodyNameToPackageOrModuleName";
 
 export async function readGoodies(): Promise<Record<string, KotlinGoody>> {
   const fileEntries = await fsPromises.readdir(GOODIES_DIRECTORY, {
@@ -26,11 +27,9 @@ export async function readGoodies(): Promise<Record<string, KotlinGoody>> {
     // eslint-disable-next-line no-await-in-loop
     const baseGoody = await readBaseGoody(packageName);
 
-    const expectedPackageName = baseGoody.name
-      .replace(/[A-Z]+/g, ([upper]) => "_" + upper.toLowerCase())
-      .replace(/[^a-z0-9]+/gi, "_")
-      .replace(/_$/, "")
-      .replace(/^_/, "");
+    const expectedPackageName = normalizeGoodyNameToPackageOrModuleName(
+      baseGoody.name,
+    );
     invariant(
       packageName === expectedPackageName,
       `Mismatched package name for goody! Expected ${JSON.stringify(expectedPackageName)} based on goody name ${JSON.stringify(baseGoody.name)} but got ${JSON.stringify(packageName)}.`,

--- a/tools/adventure-pack/src/scripts/package-goodies/normalizeGoodyNameToPackageOrModuleName.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/normalizeGoodyNameToPackageOrModuleName.ts
@@ -1,0 +1,9 @@
+export function normalizeGoodyNameToPackageOrModuleName(
+  goodyName: string,
+): string {
+  return goodyName
+    .replace(/[A-Z]+/g, ([upper]) => "_" + upper.toLowerCase())
+    .replace(/[^a-z0-9]+/gi, "_")
+    .replace(/_$/, "")
+    .replace(/^_/, "");
+}

--- a/tools/adventure-pack/src/scripts/package-goodies/python3/constants.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/python3/constants.ts
@@ -1,0 +1,3 @@
+import path from "node:path";
+
+export const GOODIES_DIRECTORY = path.join("goodies", "python3", "src");

--- a/tools/adventure-pack/src/scripts/package-goodies/python3/readBaseGoody.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/python3/readBaseGoody.ts
@@ -1,25 +1,23 @@
-import fsPromises from "node:fs/promises";
-import path from "node:path";
 import { WritableDeep } from "type-fest";
 
 import type { Python3Goody } from "../../../app/parsers/python3GoodyParser";
-
-export const GOODIES_DIRECTORY = path.join("goodies", "python3", "src");
+import { readCode } from "./readCode";
+import { readMetadata } from "./readMetadata";
 
 export type Python3GoodyBase = Omit<WritableDeep<Python3Goody>, "importedBy">;
 
 export async function readBaseGoody(
   moduleName: string,
 ): Promise<Python3GoodyBase> {
-  const code = await fsPromises.readFile(
-    path.join(GOODIES_DIRECTORY, moduleName, "__init__.py"),
-    "utf8",
-  );
+  const [code, { name }] = await Promise.all([
+    readCode(moduleName),
+    readMetadata(moduleName),
+  ]);
 
   return {
     code,
     imports: [],
     language: "python3",
-    name: moduleName,
+    name,
   };
 }

--- a/tools/adventure-pack/src/scripts/package-goodies/python3/readCode.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/python3/readCode.ts
@@ -3,9 +3,9 @@ import path from "node:path";
 
 import { GOODIES_DIRECTORY } from "./constants";
 
-export function readCode(packageName: string): Promise<string> {
+export function readCode(moduleName: string): Promise<string> {
   return fsPromises.readFile(
-    path.join(GOODIES_DIRECTORY, packageName, "Main.kt"),
+    path.join(GOODIES_DIRECTORY, moduleName, "__init__.py"),
     "utf8",
   );
 }

--- a/tools/adventure-pack/src/scripts/package-goodies/python3/readGoodies.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/python3/readGoodies.ts
@@ -4,11 +4,9 @@ import fsPromises from "node:fs/promises";
 
 import type { Python3Goody } from "../../../app/parsers/python3GoodyParser";
 import { fillOutImportedByAndSortImports } from "../fillOutImportedByAndSortImports";
-import {
-  type Python3GoodyBase,
-  readBaseGoody,
-  GOODIES_DIRECTORY,
-} from "./readBaseGoody";
+import { GOODIES_DIRECTORY } from "./constants";
+import { type Python3GoodyBase, readBaseGoody } from "./readBaseGoody";
+import { normalizeGoodyNameToPackageOrModuleName } from "../normalizeGoodyNameToPackageOrModuleName";
 
 export async function readGoodies(): Promise<Record<string, Python3Goody>> {
   const fileEntries = await fsPromises.readdir(GOODIES_DIRECTORY, {
@@ -26,7 +24,15 @@ export async function readGoodies(): Promise<Record<string, Python3Goody>> {
 
     // eslint-disable-next-line no-await-in-loop
     const baseGoody = await readBaseGoody(moduleName);
-    invariant(baseGoody.name === entry.name, "Mismatched goody name!");
+
+    const expectedModuleName = normalizeGoodyNameToPackageOrModuleName(
+      baseGoody.name,
+    );
+    invariant(
+      moduleName === expectedModuleName,
+      `Mismatched module name for goody! Expected ${JSON.stringify(expectedModuleName)} based on goody name ${JSON.stringify(baseGoody.name)} but got ${JSON.stringify(moduleName)}.`,
+    );
+
     setIfNotHasOwnOrThrow(baseGoodiesByName, baseGoody.name, baseGoody);
   }
 

--- a/tools/adventure-pack/src/scripts/package-goodies/python3/readMetadata.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/python3/readMetadata.ts
@@ -1,0 +1,22 @@
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+
+import { GOODIES_DIRECTORY } from "./constants";
+
+const metadataParser = z
+  .object({
+    name: z.string().regex(/^\S/).regex(/\S$/),
+  })
+  .strict();
+
+type Metadata = z.infer<typeof metadataParser>;
+
+export async function readMetadata(packageName: string): Promise<Metadata> {
+  const text = await fsPromises.readFile(
+    path.join(GOODIES_DIRECTORY, packageName, "goody.json"),
+    "utf8",
+  );
+
+  return metadataParser.parse(JSON.parse(text));
+}


### PR DESCRIPTION
The module name needs to be a valid Python 3 module name, whereas in the goody name it might be nice to support other characters. For example, I like calling the goody `int.digits` even though that's not a valid module name.

This also matches with how Java and Kotlin goodies already work.
