### PR TITLE
Factor out `ArraySlice` into its own TypeScript goody

### DIFF
--- a/tools/adventure-pack/goodies/typescript/Array.prototype.slidingWindows/index.ts
+++ b/tools/adventure-pack/goodies/typescript/Array.prototype.slidingWindows/index.ts
@@ -1,105 +1,25 @@
-type ArraySliceProxyHandler<T> = {
-  get(
-    target: ArraySlice<T>,
-    property: string | symbol,
-    receiver: ArraySlice<T>,
-  ): unknown;
-};
-
-class ArraySlice<T> {
-  private constructor(
-    public readonly array: ReadonlyArray<T>,
-    public readonly start: number,
-    public readonly end: number,
-  ) {}
-
-  get length(): number {
-    return this.end - this.start + 1;
-  }
-
-  at(index: number): T | undefined {
-    const adjustedIndex = index < 0 ? index + this.length : index;
-    return this.array[this.start + adjustedIndex];
-  }
-
-  *[Symbol.iterator](this: ArraySlice<T>): Generator<T, void, void> {
-    for (let i = this.start; i <= this.end; ++i) {
-      yield this.array[i];
-    }
-  }
-
-  slide(delta: number = 1): IndexableArraySlice<T> {
-    return ArraySlice.get(this.array, this.start + delta, this.end + delta);
-  }
-
-  isPrefix(): boolean {
-    return this.start === 0;
-  }
-
-  isSuffix(): boolean {
-    return this.end === this.array.length - 1;
-  }
-
-  private declare static proxyHandler?: ArraySliceProxyHandler<unknown>;
-
-  static get<T>(
-    array: ReadonlyArray<T>,
-    start: number,
-    end: number,
-  ): IndexableArraySlice<T> {
-    ArraySlice.proxyHandler ??= {
-      get(
-        target: ArraySlice<unknown>,
-        property: string | symbol,
-        receiver: ArraySlice<unknown>,
-      ): unknown {
-        if (typeof property === "string") {
-          const index = parseInt(property, 10);
-          if (String(index) === property) {
-            if (index < 0 || index >= receiver.length) {
-              return undefined;
-            }
-            return receiver.at(index);
-          }
-        }
-
-        return (target as unknown as Record<string | symbol, unknown>)[
-          property
-        ];
-      },
-    };
-
-    return new Proxy(
-      new ArraySlice(array, start, end),
-      ArraySlice.proxyHandler as ArraySliceProxyHandler<T>,
-    ) as IndexableArraySlice<T>;
-  }
-}
-
-type IndexableArraySlice<T> = ArraySlice<T> & {
-  [index: number]: T | undefined;
-};
+import { type IndexableArraySlice, ArraySlice } from "../ArraySlice";
 
 declare global {
   interface ReadonlyArray<T> {
     slidingWindows(
       this: ReadonlyArray<T>,
       windowSize: number,
-    ): Generator<ArraySlice<T>, void, void>;
+    ): Generator<IndexableArraySlice<T>, void, void>;
   }
 
   interface Array<T> {
     slidingWindows(
       this: ReadonlyArray<T>,
       windowSize: number,
-    ): Generator<ArraySlice<T>, void, void>;
+    ): Generator<IndexableArraySlice<T>, void, void>;
   }
 }
 
 Array.prototype.slidingWindows = function* <T>(
   this: ReadonlyArray<T>,
   windowSize: number,
-): Generator<ArraySlice<T>, void, void> {
+): Generator<IndexableArraySlice<T>, void, void> {
   for (
     let win: IndexableArraySlice<T> | null = ArraySlice.get(
       this,
@@ -112,7 +32,3 @@ Array.prototype.slidingWindows = function* <T>(
     yield win;
   }
 };
-
-// Needed to fix the error "Augmentations for the global scope can only be directly nested in external modules or ambient module declarations. ts(2669)"
-// See: https://stackoverflow.com/questions/57132428/augmentations-for-the-global-scope-can-only-be-directly-nested-in-external-modul
-export {};

--- a/tools/adventure-pack/goodies/typescript/ArraySlice/index.ts
+++ b/tools/adventure-pack/goodies/typescript/ArraySlice/index.ts
@@ -1,0 +1,79 @@
+type ArraySliceProxyHandler<T> = {
+  get(
+    target: ArraySlice<T>,
+    property: PropertyKey,
+    receiver: ArraySlice<T>,
+  ): unknown;
+};
+
+export type IndexableArraySlice<T> = ArraySlice<T> & {
+  [index: number]: T | undefined;
+};
+
+export class ArraySlice<T> {
+  private constructor(
+    public readonly array: ReadonlyArray<T>,
+    public readonly start: number,
+    public readonly end: number,
+  ) {}
+
+  get length(): number {
+    return this.end - this.start + 1;
+  }
+
+  at(index: number): T | undefined {
+    const adjustedIndex = index < 0 ? index + this.length : index;
+    return this.array[this.start + adjustedIndex];
+  }
+
+  *[Symbol.iterator](this: ArraySlice<T>): Generator<T, void, void> {
+    for (let i = this.start; i <= this.end; ++i) {
+      yield this.array[i];
+    }
+  }
+
+  slide(delta: number = 1): IndexableArraySlice<T> {
+    return ArraySlice.get(this.array, this.start + delta, this.end + delta);
+  }
+
+  isPrefix(): boolean {
+    return this.start === 0;
+  }
+
+  isSuffix(): boolean {
+    return this.end === this.array.length - 1;
+  }
+
+  private declare static proxyHandler?: ArraySliceProxyHandler<unknown>;
+
+  static get<T>(
+    array: ReadonlyArray<T>,
+    start: number,
+    end: number,
+  ): IndexableArraySlice<T> {
+    ArraySlice.proxyHandler ??= {
+      get(
+        target: ArraySlice<unknown>,
+        property: PropertyKey,
+        receiver: ArraySlice<unknown>,
+      ): unknown {
+        if (typeof property === "string" || typeof property === "number") {
+          const index = parseInt(String(property), 10);
+          if (String(index) === String(property)) {
+            if (index < 0 || index >= receiver.length) {
+              return undefined;
+            }
+            return receiver.at(index);
+          }
+        }
+
+        return (target as unknown as Record<PropertyKey, unknown>)[property];
+      },
+    };
+
+    return new Proxy(
+      new ArraySlice(array, start, end),
+      ArraySlice.proxyHandler as ArraySliceProxyHandler<T>,
+    ) as IndexableArraySlice<T>;
+  }
+}

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -140,9 +140,9 @@ class ArraySlice {
   static get(array, start, end) {
     ArraySlice.proxyHandler ??= {
       get(target, property, receiver) {
-        if (typeof property === "string") {
-          const index = parseInt(property, 10);
-          if (String(index) === property) {
+        if (typeof property === "string" || typeof property === "number") {
+          const index = parseInt(String(property), 10);
+          if (String(index) === String(property)) {
             if (index < 0 || index >= receiver.length) {
               return undefined;
             }
@@ -184,6 +184,72 @@ Array.prototype.swap = function (i, j) {
   this[i] = this[j];
   this[j] = tmp;
 };
+
+/////////////////////////// END ADVENTURE PACK CODE ////////////////////////////"
+`;
+
+exports[`App can equip single goody: JavaScript ArraySlice 1`] = `
+"////////////////////////// BEGIN ADVENTURE PACK CODE ///////////////////////////
+// Adventure Pack commit fake-commit-hash
+// Running at: https://example.com/
+
+class ArraySlice {
+  constructor(array, start, end) {
+    this.array = array;
+    this.start = start;
+    this.end = end;
+  }
+
+  get length() {
+    return this.end - this.start + 1;
+  }
+
+  at(index) {
+    const adjustedIndex = index < 0 ? index + this.length : index;
+    return this.array[this.start + adjustedIndex];
+  }
+
+  *[Symbol.iterator]() {
+    for (let i = this.start; i <= this.end; ++i) {
+      yield this.array[i];
+    }
+  }
+
+  slide(delta = 1) {
+    return ArraySlice.get(this.array, this.start + delta, this.end + delta);
+  }
+
+  isPrefix() {
+    return this.start === 0;
+  }
+
+  isSuffix() {
+    return this.end === this.array.length - 1;
+  }
+
+  static get(array, start, end) {
+    ArraySlice.proxyHandler ??= {
+      get(target, property, receiver) {
+        if (typeof property === "string" || typeof property === "number") {
+          const index = parseInt(String(property), 10);
+          if (String(index) === String(property)) {
+            if (index < 0 || index >= receiver.length) {
+              return undefined;
+            }
+            return receiver.at(index);
+          }
+        }
+
+        return target[property];
+      },
+    };
+
+    return new Proxy(
+      new ArraySlice(array, start, end),
+      ArraySlice.proxyHandler,
+    );
+  }
+}
 
 /////////////////////////// END ADVENTURE PACK CODE ////////////////////////////"
 `;
@@ -911,23 +977,27 @@ declare global {
     slidingWindows(
       this: ReadonlyArray<T>,
       windowSize: number,
-    ): Generator<ArraySlice<T>, void, void>;
+    ): Generator<IndexableArraySlice<T>, void, void>;
   }
 
   interface ReadonlyArray<T> {
     slidingWindows(
       this: ReadonlyArray<T>,
       windowSize: number,
-    ): Generator<ArraySlice<T>, void, void>;
+    ): Generator<IndexableArraySlice<T>, void, void>;
   }
 }
 
 type ArraySliceProxyHandler<T> = {
   get(
     target: ArraySlice<T>,
-    property: string | symbol,
+    property: PropertyKey,
     receiver: ArraySlice<T>,
   ): unknown;
+};
+
+type IndexableArraySlice<T> = ArraySlice<T> & {
+  [index: number]: T | undefined;
 };
 
 class ArraySlice<T> {
@@ -974,12 +1044,12 @@ class ArraySlice<T> {
     ArraySlice.proxyHandler ??= {
       get(
         target: ArraySlice<unknown>,
-        property: string | symbol,
+        property: PropertyKey,
         receiver: ArraySlice<unknown>,
       ): unknown {
-        if (typeof property === "string") {
-          const index = parseInt(property, 10);
-          if (String(index) === property) {
+        if (typeof property === "string" || typeof property === "number") {
+          const index = parseInt(String(property), 10);
+          if (String(index) === String(property)) {
             if (index < 0 || index >= receiver.length) {
               return undefined;
             }
@@ -987,9 +1057,7 @@ class ArraySlice<T> {
           }
         }
 
-        return (target as unknown as Record<string | symbol, unknown>)[
-          property
-        ];
+        return (target as unknown as Record<PropertyKey, unknown>)[property];
       },
     };
 
@@ -1000,14 +1068,10 @@ class ArraySlice<T> {
   }
 }
 
-type IndexableArraySlice<T> = ArraySlice<T> & {
-  [index: number]: T | undefined;
-};
-
 Array.prototype.slidingWindows = function* <T>(
   this: ReadonlyArray<T>,
   windowSize: number,
-): Generator<ArraySlice<T>, void, void> {
+): Generator<IndexableArraySlice<T>, void, void> {
   for (
     let win: IndexableArraySlice<T> | null = ArraySlice.get(
       this,
@@ -1040,6 +1104,94 @@ Array.prototype.swap = function <T>(this: T[], i: number, j: number): void {
   this[i] = this[j];
   this[j] = tmp;
 };
+
+/////////////////////////// END ADVENTURE PACK CODE ////////////////////////////"
+`;
+
+exports[`App can equip single goody: TypeScript ArraySlice 1`] = `
+"////////////////////////// BEGIN ADVENTURE PACK CODE ///////////////////////////
+// Adventure Pack commit fake-commit-hash
+// Running at: https://example.com/
+
+type ArraySliceProxyHandler<T> = {
+  get(
+    target: ArraySlice<T>,
+    property: PropertyKey,
+    receiver: ArraySlice<T>,
+  ): unknown;
+};
+
+type IndexableArraySlice<T> = ArraySlice<T> & {
+  [index: number]: T | undefined;
+};
+
+class ArraySlice<T> {
+  private constructor(
+    public readonly array: ReadonlyArray<T>,
+    public readonly start: number,
+    public readonly end: number,
+  ) {}
+
+  get length(): number {
+    return this.end - this.start + 1;
+  }
+
+  at(index: number): T | undefined {
+    const adjustedIndex = index < 0 ? index + this.length : index;
+    return this.array[this.start + adjustedIndex];
+  }
+
+  *[Symbol.iterator](this: ArraySlice<T>): Generator<T, void, void> {
+    for (let i = this.start; i <= this.end; ++i) {
+      yield this.array[i];
+    }
+  }
+
+  slide(delta: number = 1): IndexableArraySlice<T> {
+    return ArraySlice.get(this.array, this.start + delta, this.end + delta);
+  }
+
+  isPrefix(): boolean {
+    return this.start === 0;
+  }
+
+  isSuffix(): boolean {
+    return this.end === this.array.length - 1;
+  }
+
+  private declare static proxyHandler?: ArraySliceProxyHandler<unknown>;
+
+  static get<T>(
+    array: ReadonlyArray<T>,
+    start: number,
+    end: number,
+  ): IndexableArraySlice<T> {
+    ArraySlice.proxyHandler ??= {
+      get(
+        target: ArraySlice<unknown>,
+        property: PropertyKey,
+        receiver: ArraySlice<unknown>,
+      ): unknown {
+        if (typeof property === "string" || typeof property === "number") {
+          const index = parseInt(String(property), 10);
+          if (String(index) === String(property)) {
+            if (index < 0 || index >= receiver.length) {
+              return undefined;
+            }
+            return receiver.at(index);
+          }
+        }
+
+        return (target as unknown as Record<PropertyKey, unknown>)[property];
+      },
+    };
+
+    return new Proxy(
+      new ArraySlice(array, start, end),
+      ArraySlice.proxyHandler as ArraySliceProxyHandler<T>,
+    ) as IndexableArraySlice<T>;
+  }
+}
 
 /////////////////////////// END ADVENTURE PACK CODE ////////////////////////////"
 `;

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -73,7 +73,29 @@ final class AP {
 `;
 
 exports[`App can render goody: JavaScript Array.prototype.slidingWindows 1`] = `
-"class ArraySlice {
+"import "ArraySlice";
+
+Array.prototype.slidingWindows = function* (windowSize) {
+  for (
+    let win = ArraySlice.get(this, 0, windowSize - 1);
+    win != null;
+    win = win.isSuffix() ? null : win.slide()
+  ) {
+    yield win;
+  }
+};"
+`;
+
+exports[`App can render goody: JavaScript Array.prototype.swap 1`] = `
+"Array.prototype.swap = function (i, j) {
+  const tmp = this[i];
+  this[i] = this[j];
+  this[j] = tmp;
+};"
+`;
+
+exports[`App can render goody: JavaScript ArraySlice 1`] = `
+"export class ArraySlice {
   constructor(array, start, end) {
     this.array = array;
     this.start = start;
@@ -110,9 +132,9 @@ exports[`App can render goody: JavaScript Array.prototype.slidingWindows 1`] = `
   static get(array, start, end) {
     ArraySlice.proxyHandler ??= {
       get(target, property, receiver) {
-        if (typeof property === "string") {
-          const index = parseInt(property, 10);
-          if (String(index) === property) {
+        if (typeof property === "string" || typeof property === "number") {
+          const index = parseInt(String(property), 10);
+          if (String(index) === String(property)) {
             if (index < 0 || index >= receiver.length) {
               return undefined;
             }
@@ -129,25 +151,7 @@ exports[`App can render goody: JavaScript Array.prototype.slidingWindows 1`] = `
       ArraySlice.proxyHandler,
     );
   }
-}
-
-Array.prototype.slidingWindows = function* (windowSize) {
-  for (
-    let win = ArraySlice.get(this, 0, windowSize - 1);
-    win != null;
-    win = win.isSuffix() ? null : win.slide()
-  ) {
-    yield win;
-  }
-};"
-`;
-
-exports[`App can render goody: JavaScript Array.prototype.swap 1`] = `
-"Array.prototype.swap = function (i, j) {
-  const tmp = this[i];
-  this[i] = this[j];
-  this[j] = tmp;
-};"
+}"
 `;
 
 exports[`App can render goody: JavaScript BinaryHeap 1`] = `
@@ -559,31 +563,70 @@ del set_up_adventure_pack"
 `;
 
 exports[`App can render goody: TypeScript Array.prototype.slidingWindows 1`] = `
-"declare global {
+"import "ArraySlice";
+
+declare global {
   interface Array<T> {
     slidingWindows(
       this: ReadonlyArray<T>,
       windowSize: number,
-    ): Generator<ArraySlice<T>, void, void>;
+    ): Generator<IndexableArraySlice<T>, void, void>;
   }
 
   interface ReadonlyArray<T> {
     slidingWindows(
       this: ReadonlyArray<T>,
       windowSize: number,
-    ): Generator<ArraySlice<T>, void, void>;
+    ): Generator<IndexableArraySlice<T>, void, void>;
   }
 }
 
-type ArraySliceProxyHandler<T> = {
+Array.prototype.slidingWindows = function* <T>(
+  this: ReadonlyArray<T>,
+  windowSize: number,
+): Generator<IndexableArraySlice<T>, void, void> {
+  for (
+    let win: IndexableArraySlice<T> | null = ArraySlice.get(
+      this,
+      0,
+      windowSize - 1,
+    );
+    win != null;
+    win = win.isSuffix() ? null : win.slide()
+  ) {
+    yield win;
+  }
+};"
+`;
+
+exports[`App can render goody: TypeScript Array.prototype.swap 1`] = `
+"declare global {
+  interface Array<T> {
+    swap(this: T[], i: number, j: number): void;
+  }
+}
+
+Array.prototype.swap = function <T>(this: T[], i: number, j: number): void {
+  const tmp = this[i];
+  this[i] = this[j];
+  this[j] = tmp;
+};"
+`;
+
+exports[`App can render goody: TypeScript ArraySlice 1`] = `
+"type ArraySliceProxyHandler<T> = {
   get(
     target: ArraySlice<T>,
-    property: string | symbol,
+    property: PropertyKey,
     receiver: ArraySlice<T>,
   ): unknown;
 };
 
-class ArraySlice<T> {
+export type IndexableArraySlice<T> = ArraySlice<T> & {
+  [index: number]: T | undefined;
+};
+
+export class ArraySlice<T> {
   private constructor(
     public readonly array: ReadonlyArray<T>,
     public readonly start: number,
@@ -627,12 +670,12 @@ class ArraySlice<T> {
     ArraySlice.proxyHandler ??= {
       get(
         target: ArraySlice<unknown>,
-        property: string | symbol,
+        property: PropertyKey,
         receiver: ArraySlice<unknown>,
       ): unknown {
-        if (typeof property === "string") {
-          const index = parseInt(property, 10);
-          if (String(index) === property) {
+        if (typeof property === "string" || typeof property === "number") {
+          const index = parseInt(String(property), 10);
+          if (String(index) === String(property)) {
             if (index < 0 || index >= receiver.length) {
               return undefined;
             }
@@ -640,9 +683,7 @@ class ArraySlice<T> {
           }
         }
 
-        return (target as unknown as Record<string | symbol, unknown>)[
-          property
-        ];
+        return (target as unknown as Record<PropertyKey, unknown>)[property];
       },
     };
 
@@ -651,42 +692,7 @@ class ArraySlice<T> {
       ArraySlice.proxyHandler as ArraySliceProxyHandler<T>,
     ) as IndexableArraySlice<T>;
   }
-}
-
-type IndexableArraySlice<T> = ArraySlice<T> & {
-  [index: number]: T | undefined;
-};
-
-Array.prototype.slidingWindows = function* <T>(
-  this: ReadonlyArray<T>,
-  windowSize: number,
-): Generator<ArraySlice<T>, void, void> {
-  for (
-    let win: IndexableArraySlice<T> | null = ArraySlice.get(
-      this,
-      0,
-      windowSize - 1,
-    );
-    win != null;
-    win = win.isSuffix() ? null : win.slide()
-  ) {
-    yield win;
-  }
-};"
-`;
-
-exports[`App can render goody: TypeScript Array.prototype.swap 1`] = `
-"declare global {
-  interface Array<T> {
-    swap(this: T[], i: number, j: number): void;
-  }
-}
-
-Array.prototype.swap = function <T>(this: T[], i: number, j: number): void {
-  const tmp = this[i];
-  this[i] = this[j];
-  this[j] = tmp;
-};"
+}"
 `;
 
 exports[`App can render goody: TypeScript BinaryHeap 1`] = `


### PR DESCRIPTION
I would like to use the `ArraySlice` class to do some work with combinations, permutations, and subsets. It will be nice to have it as a separate goody for this purpose.
