### PR TITLE
Add Java toIterable goody

### DIFF
--- a/tools/adventure-pack/goodies/java/src/to_iterable/AP.java
+++ b/tools/adventure-pack/goodies/java/src/to_iterable/AP.java
@@ -1,0 +1,8 @@
+import java.util.Iterator;
+
+final class AP {
+
+  public static <T> Iterable<T> toIterable(Iterator<T> iterator) {
+    return () -> iterator;
+  }
+}

--- a/tools/adventure-pack/goodies/java/src/to_iterable/goody.json
+++ b/tools/adventure-pack/goodies/java/src/to_iterable/goody.json
@@ -1,0 +1,3 @@
+{
+  "name": "toIterable"
+}

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -108,6 +108,24 @@ final class AP {
 /////////////////////////// END ADVENTURE PACK CODE ////////////////////////////"
 `;
 
+exports[`App can equip single goody: Java toIterable 1`] = `
+"////////////////////////// BEGIN ADVENTURE PACK CODE ///////////////////////////
+// Adventure Pack commit fake-commit-hash
+// Running at: https://example.com/
+
+import java.util.Iterator;
+
+final class AP {
+  private AP() {}
+
+  public static <T> Iterable<T> toIterable(Iterator<T> iterator) {
+    return () -> iterator;
+  }
+}
+
+/////////////////////////// END ADVENTURE PACK CODE ////////////////////////////"
+`;
+
 exports[`App can equip single goody: JavaScript Array.prototype.slidingWindows 1`] = `
 "////////////////////////// BEGIN ADVENTURE PACK CODE ///////////////////////////
 // Adventure Pack commit fake-commit-hash

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -78,6 +78,20 @@ final class AP {
 }"
 `;
 
+exports[`App can render goody: Java toIterable 1`] = `
+"package to_iterable;
+
+import java.util.Iterator;
+
+final class AP {
+  private AP() {}
+
+  public static <T> Iterable<T> toIterable(Iterator<T> iterator) {
+    return () -> iterator;
+  }
+}"
+`;
+
 exports[`App can render goody: JavaScript Array.prototype.slidingWindows 1`] = `
 "class ArraySlice {
   constructor(array, start, end) {

--- a/tools/adventure-pack/src/app/mergeJavaCode.ts
+++ b/tools/adventure-pack/src/app/mergeJavaCode.ts
@@ -7,7 +7,13 @@ const ADVENTURE_PACK_CLASS_NAME = "AP";
 
 export function mergeJavaCode(goodies: Iterable<ReadonlyDeep<JavaGoody>>) {
   const classes: Record<string, { code: string[]; declaration: string }> = {};
+  const coreImports: Set<string> = new Set();
+
   for (const goody of goodies) {
+    for (const im of goody.coreImports) {
+      coreImports.add(im);
+    }
+
     for (const className of Object.keys(goody.codeByClass)) {
       invariant(
         classes[className] == null || className === ADVENTURE_PACK_CLASS_NAME,
@@ -30,6 +36,10 @@ export function mergeJavaCode(goodies: Iterable<ReadonlyDeep<JavaGoody>>) {
   }
 
   const res: string[] = [];
+  if (coreImports.size > 0) {
+    res.push([...coreImports].sort().join("\n"));
+  }
+
   for (const className of Object.keys(classes)) {
     const classData = classes[className];
     const codeSections = classData.code.filter(Boolean);

--- a/tools/adventure-pack/src/app/parsers/javaGoodyParser.ts
+++ b/tools/adventure-pack/src/app/parsers/javaGoodyParser.ts
@@ -15,6 +15,7 @@ export const javaGoodyParser = goodyBaseParser
         })
         .strict(),
     ),
+    coreImports: z.array(nonBlankStringParser),
     importsCode: z.string(),
     language: z.literal("java"),
     packageName: z

--- a/tools/adventure-pack/src/scripts/package-goodies/extractJavaesqueImports.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/extractJavaesqueImports.ts
@@ -2,10 +2,13 @@ import { getLines, isStringEmptyOrWhitespaceOnly } from "@code-chronicles/util";
 
 export function extractJavaesqueImports(code: string): {
   codeWithoutImports: string;
+  coreImports: string[];
   imports: Set<string>;
   importsCode: string;
 } {
   const lines = Array.from(getLines(code));
+
+  const coreImports: string[] = [];
   const imports = new Set<string>();
   const importsCode: string[] = [];
 
@@ -19,6 +22,14 @@ export function extractJavaesqueImports(code: string): {
     if (packageNameMatch != null) {
       // TODO: verify that the package name matches what's expected
       lines.shift();
+      continue;
+    }
+
+    const coreImmportMatch = lines[0].match(
+      /^import\s+(?:static\s+)?(?:java|javafx|javax\.)/,
+    );
+    if (coreImmportMatch != null) {
+      coreImports.push(lines.shift()!.replace(/\n+$/, ""));
       continue;
     }
 
@@ -41,6 +52,7 @@ export function extractJavaesqueImports(code: string): {
 
   return {
     codeWithoutImports: lines.join(""),
+    coreImports,
     imports,
     importsCode: importsCode.join(""),
   };

--- a/tools/adventure-pack/src/scripts/package-goodies/java/readBaseGoody.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/readBaseGoody.ts
@@ -16,13 +16,14 @@ export async function readBaseGoody(
     readMetadata(packageName),
   ]);
 
-  const { codeWithoutImports, imports, importsCode } =
+  const { codeWithoutImports, coreImports, imports, importsCode } =
     extractJavaesqueImports(codeWithImports);
 
   const codeByClass = splitCodeIntoClasses(codeWithoutImports);
 
   return {
     codeByClass,
+    coreImports,
     imports: Array.from(imports),
     importsCode,
     language: "java",

--- a/tools/adventure-pack/src/scripts/package-goodies/java/readGoodies.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/readGoodies.ts
@@ -48,7 +48,7 @@ export async function readGoodies(): Promise<Record<string, JavaGoody>> {
       const importedBaseGoody = baseGoodiesByPackageName[im];
       invariant(
         importedBaseGoody != null,
-        `Unknown import ${JSON.stringify(im)} in ${importedBaseGoody.name}`,
+        `Unknown import ${JSON.stringify(im)} in goody ${JSON.stringify(baseGoody.name)}.`,
       );
       return importedBaseGoody.name;
     });

--- a/tools/adventure-pack/src/scripts/package-goodies/kotlin/readGoodies.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/kotlin/readGoodies.ts
@@ -48,7 +48,7 @@ export async function readGoodies(): Promise<Record<string, KotlinGoody>> {
       const importedBaseGoody = baseGoodiesByPackageName[im];
       invariant(
         importedBaseGoody != null,
-        `Unknown import ${JSON.stringify(im)} in ${importedBaseGoody.name}`,
+        `Unknown import ${JSON.stringify(im)} in goody ${JSON.stringify(baseGoody.name)}.`,
       );
       return importedBaseGoody.name;
     });


### PR DESCRIPTION
To be used in a for-each loop, an object must implement the Iterable interface. Similar to the TypeScript counterpart, let's add a Java goody that can transform an Iterator into an Iterable.
