### PR TITLE
Ensure the `AP` class is last when merging Java code

### DIFF
--- a/tools/adventure-pack/goodies/java/src/traverse_inorder/AP.java
+++ b/tools/adventure-pack/goodies/java/src/traverse_inorder/AP.java
@@ -42,11 +42,7 @@ class TreeNode {
 
   // TODO: support comments outside a class in code extraction
 
-  // TODO: don't include this class in the goody, since it's automatically defined by LeetCode
-
   // TODO: get coreImports to be first in generated output
-
-  // TODO: alphabetize classes when merging Java code
 
   int val;
   TreeNode left;

--- a/tools/adventure-pack/src/app/mergeJavaCode.ts
+++ b/tools/adventure-pack/src/app/mergeJavaCode.ts
@@ -33,6 +33,9 @@ export function mergeJavaCode(goodies: Iterable<ReadonlyDeep<JavaGoody>>) {
     adventurePackClass.code.unshift(
       `  private ${ADVENTURE_PACK_CLASS_NAME}() {}`,
     );
+
+    delete classes[ADVENTURE_PACK_CLASS_NAME];
+    classes[ADVENTURE_PACK_CLASS_NAME] = adventurePackClass;
   }
 
   const res: string[] = [];


### PR DESCRIPTION
This is the shared class for `public static` utility functions, so it seems like it should be last (or perhaps first?) relative to the other classes.
