### PR TITLE
Update Java `primes()` goody to return an `IntStream` rather than a `Stream<Integer>`

### DIFF
--- a/tools/adventure-pack/goodies/java/build.gradle.kts
+++ b/tools/adventure-pack/goodies/java/build.gradle.kts
@@ -51,8 +51,6 @@ tasks.register<KtfmtFormatTask>("ktfmtCustom") {
 
 tasks.withType<JavaCompile> {
   options.compilerArgs.add("-Xlint:all")
-  // TODO: re-enable the options once we can apply @SuppressWarnings("overloads") to
-  // IterableIntStream
-  // options.compilerArgs.add("-Werror")
+  options.compilerArgs.add("-Werror")
   options.isWarnings = true
 }

--- a/tools/adventure-pack/goodies/java/build.gradle.kts
+++ b/tools/adventure-pack/goodies/java/build.gradle.kts
@@ -51,6 +51,8 @@ tasks.register<KtfmtFormatTask>("ktfmtCustom") {
 
 tasks.withType<JavaCompile> {
   options.compilerArgs.add("-Xlint:all")
-  options.compilerArgs.add("-Werror")
+  // TODO: re-enable the options once we can apply @SuppressWarnings("overloads") to
+  // IterableIntStream
+  // options.compilerArgs.add("-Werror")
   options.isWarnings = true
 }

--- a/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
+++ b/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
@@ -10,6 +10,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+@SuppressWarnings("overloads")
 public interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
   public Spliterator.OfInt spliterator();

--- a/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
+++ b/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
@@ -12,12 +12,6 @@ import java.util.stream.StreamSupport;
 
 public interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
-  public void forEach(Consumer<? super Integer> action);
-
-  @Override
-  public void forEach(IntConsumer action);
-
-  @Override
   public Spliterator.OfInt spliterator();
 
   public static IterableIntStream from(final Iterable<Integer> iterable) {

--- a/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
+++ b/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
@@ -4,12 +4,16 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Iterator;
 import java.util.Spliterator;
+import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public interface IterableIntStream extends Iterable<Integer>, IntStream {
+  @Override
+  public void forEach(Consumer<? super Integer> action);
+
   @Override
   public void forEach(IntConsumer action);
 

--- a/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
+++ b/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
@@ -4,14 +4,14 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Iterator;
 import java.util.Spliterator;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
-  public void forEach(Consumer<? super Integer> action);
+  public void forEach(IntConsumer action);
 
   @Override
   public Spliterator.OfInt spliterator();

--- a/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
+++ b/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
@@ -10,7 +10,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-@SuppressWarnings("overloads")
 public interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
   public Spliterator.OfInt spliterator();

--- a/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
+++ b/tools/adventure-pack/goodies/java/src/iterable_int_stream/IterableIntStream.java
@@ -1,0 +1,52 @@
+package iterable_int_stream;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public interface IterableIntStream extends Iterable<Integer>, IntStream {
+  @Override
+  public void forEach(Consumer<? super Integer> action);
+
+  @Override
+  public Spliterator.OfInt spliterator();
+
+  public static IterableIntStream from(final Iterable<Integer> iterable) {
+    return from(iterable.spliterator());
+  }
+
+  public static IterableIntStream from(final Iterator<Integer> iterator) {
+    return from(() -> iterator);
+  }
+
+  public static IterableIntStream from(final Spliterator<Integer> spliterator) {
+    return from(StreamSupport.stream(spliterator, false));
+  }
+
+  public static IterableIntStream from(final Spliterator.OfInt spliterator) {
+    return from(StreamSupport.intStream(spliterator, false));
+  }
+
+  public static IterableIntStream from(final Stream<Integer> stream) {
+    return from(stream.mapToInt(i -> i));
+  }
+
+  public static IterableIntStream from(final IntStream stream) {
+    @SuppressWarnings("unchecked")
+    var proxy = (IterableIntStream) Proxy.newProxyInstance(
+      ClassLoader.getSystemClassLoader(),
+      new Class<?>[] { IterableIntStream.class },
+      (Object _proxy, Method method, Object[] args) ->
+        IntStream.class.getMethod(
+            method.getName(),
+            method.getParameterTypes()
+          ).invoke(stream, args)
+    );
+    return proxy;
+  }
+}

--- a/tools/adventure-pack/goodies/java/src/iterable_int_stream/goody.json
+++ b/tools/adventure-pack/goodies/java/src/iterable_int_stream/goody.json
@@ -1,0 +1,3 @@
+{
+  "name": "IterableIntStream"
+}

--- a/tools/adventure-pack/goodies/java/src/primes/AP.java
+++ b/tools/adventure-pack/goodies/java/src/primes/AP.java
@@ -1,17 +1,17 @@
 package primes;
 
-import iterable_stream.IterableStream;
+import iterable_int_stream.IterableIntStream;
 import java.util.ArrayList;
 import java.util.List;
 import simple_iterator.SimpleIterator;
 
 public final class AP {
 
-  public static IterableStream<Integer> primes() {
+  public static IterableIntStream primes() {
     final boolean[] yieldedTwo = { false };
     final List<Integer> oddPrimes = new ArrayList<>();
 
-    return IterableStream.from(
+    return IterableIntStream.from(
       SimpleIterator.toIterator(() -> {
         if (!yieldedTwo[0]) {
           yieldedTwo[0] = true;

--- a/tools/adventure-pack/goodies/java/src/primes/Test.java
+++ b/tools/adventure-pack/goodies/java/src/primes/Test.java
@@ -1,7 +1,7 @@
 package primes;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static primes.AP.primes;
 
 import java.util.List;
@@ -11,7 +11,7 @@ class PrimeTest {
 
   @Test
   public void generatesTheCorrectSmallPrimes() {
-    var smallPrimes = List.of(
+    int[] smallPrimes = {
       2,
       3,
       5,
@@ -28,11 +28,11 @@ class PrimeTest {
       43,
       47,
       53,
-      59
-    );
-    assertIterableEquals(
+      59,
+    };
+    assertArrayEquals(
       smallPrimes,
-      primes().limit(smallPrimes.size()).toList()
+      primes().limit(smallPrimes.length).toArray()
     );
   }
 

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -9,14 +9,14 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Iterator;
 import java.util.Spliterator;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
-  public void forEach(Consumer<? super Integer> action);
+  public void forEach(IntConsumer action);
 
   @Override
   public Spliterator.OfInt spliterator();
@@ -310,14 +310,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
-  public void forEach(Consumer<? super Integer> action);
+  public void forEach(IntConsumer action);
 
   @Override
   public Spliterator.OfInt spliterator();

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`App can equip single goody: Java IterableIntStream 1`] = `
+"////////////////////////// BEGIN ADVENTURE PACK CODE ///////////////////////////
+// Adventure Pack commit fake-commit-hash
+// Running at: https://example.com/
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+interface IterableIntStream extends Iterable<Integer>, IntStream {
+  @Override
+  public void forEach(Consumer<? super Integer> action);
+
+  @Override
+  public Spliterator.OfInt spliterator();
+
+  public static IterableIntStream from(final Iterable<Integer> iterable) {
+    return from(iterable.spliterator());
+  }
+
+  public static IterableIntStream from(final Iterator<Integer> iterator) {
+    return from(() -> iterator);
+  }
+
+  public static IterableIntStream from(final Spliterator<Integer> spliterator) {
+    return from(StreamSupport.stream(spliterator, false));
+  }
+
+  public static IterableIntStream from(final Spliterator.OfInt spliterator) {
+    return from(StreamSupport.intStream(spliterator, false));
+  }
+
+  public static IterableIntStream from(final Stream<Integer> stream) {
+    return from(stream.mapToInt(i -> i));
+  }
+
+  public static IterableIntStream from(final IntStream stream) {
+    @SuppressWarnings("unchecked")
+    var proxy = (IterableIntStream) Proxy.newProxyInstance(
+      ClassLoader.getSystemClassLoader(),
+      new Class<?>[] { IterableIntStream.class },
+      (Object _proxy, Method method, Object[] args) ->
+        IntStream.class.getMethod(
+            method.getName(),
+            method.getParameterTypes()
+          ).invoke(stream, args)
+    );
+    return proxy;
+  }
+}
+
+/////////////////////////// END ADVENTURE PACK CODE ////////////////////////////"
+`;
+
 exports[`App can equip single goody: Java IterableStream 1`] = `
 "////////////////////////// BEGIN ADVENTURE PACK CODE ///////////////////////////
 // Adventure Pack commit fake-commit-hash
@@ -252,35 +311,44 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-interface IterableStream<T> extends Iterable<T>, Stream<T> {
+interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
-  public void forEach(Consumer<? super T> action);
+  public void forEach(Consumer<? super Integer> action);
 
   @Override
-  public Spliterator<T> spliterator();
+  public Spliterator.OfInt spliterator();
 
-  public static <T> IterableStream<T> from(final Iterable<T> iterable) {
+  public static IterableIntStream from(final Iterable<Integer> iterable) {
     return from(iterable.spliterator());
   }
 
-  public static <T> IterableStream<T> from(final Iterator<T> iterator) {
+  public static IterableIntStream from(final Iterator<Integer> iterator) {
     return from(() -> iterator);
   }
 
-  public static <T> IterableStream<T> from(final Spliterator<T> spliterator) {
+  public static IterableIntStream from(final Spliterator<Integer> spliterator) {
     return from(StreamSupport.stream(spliterator, false));
   }
 
-  public static <T> IterableStream<T> from(final Stream<T> stream) {
+  public static IterableIntStream from(final Spliterator.OfInt spliterator) {
+    return from(StreamSupport.intStream(spliterator, false));
+  }
+
+  public static IterableIntStream from(final Stream<Integer> stream) {
+    return from(stream.mapToInt(i -> i));
+  }
+
+  public static IterableIntStream from(final IntStream stream) {
     @SuppressWarnings("unchecked")
-    var proxy = (IterableStream<T>) Proxy.newProxyInstance(
+    var proxy = (IterableIntStream) Proxy.newProxyInstance(
       ClassLoader.getSystemClassLoader(),
-      new Class<?>[] { IterableStream.class },
+      new Class<?>[] { IterableIntStream.class },
       (Object _proxy, Method method, Object[] args) ->
-        Stream.class.getMethod(
+        IntStream.class.getMethod(
             method.getName(),
             method.getParameterTypes()
           ).invoke(stream, args)
@@ -340,11 +408,11 @@ interface SimpleIterator<T> {
 final class AP {
   private AP() {}
 
-  public static IterableStream<Integer> primes() {
+  public static IterableIntStream primes() {
     final boolean[] yieldedTwo = { false };
     final List<Integer> oddPrimes = new ArrayList<>();
 
-    return IterableStream.from(
+    return IterableIntStream.from(
       SimpleIterator.toIterator(() -> {
         if (!yieldedTwo[0]) {
           yieldedTwo[0] = true;

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -9,12 +9,16 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Iterator;
 import java.util.Spliterator;
+import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
+  @Override
+  public void forEach(Consumer<? super Integer> action);
+
   @Override
   public void forEach(IntConsumer action);
 
@@ -310,12 +314,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
+import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
+  @Override
+  public void forEach(Consumer<? super Integer> action);
+
   @Override
   public void forEach(IntConsumer action);
 

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -17,12 +17,6 @@ import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
-  public void forEach(Consumer<? super Integer> action);
-
-  @Override
-  public void forEach(IntConsumer action);
-
-  @Override
   public Spliterator.OfInt spliterator();
 
   public static IterableIntStream from(final Iterable<Integer> iterable) {
@@ -321,12 +315,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
-  @Override
-  public void forEach(Consumer<? super Integer> action);
-
-  @Override
-  public void forEach(IntConsumer action);
-
   @Override
   public Spliterator.OfInt spliterator();
 

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -15,6 +15,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+@SuppressWarnings("overloads")
 interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
   public Spliterator.OfInt spliterator();
@@ -314,6 +315,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+@SuppressWarnings("overloads")
 interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
   public Spliterator.OfInt spliterator();

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -7,14 +7,14 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Iterator;
 import java.util.Spliterator;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
-  public void forEach(Consumer<? super Integer> action);
+  public void forEach(IntConsumer action);
 
   @Override
   public Spliterator.OfInt spliterator();

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -7,12 +7,16 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Iterator;
 import java.util.Spliterator;
+import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
+  @Override
+  public void forEach(Consumer<? super Integer> action);
+
   @Override
   public void forEach(IntConsumer action);
 

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -15,12 +15,6 @@ import java.util.stream.StreamSupport;
 
 interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
-  public void forEach(Consumer<? super Integer> action);
-
-  @Override
-  public void forEach(IntConsumer action);
-
-  @Override
   public Spliterator.OfInt spliterator();
 
   public static IterableIntStream from(final Iterable<Integer> iterable) {

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`App can render goody: Java IterableIntStream 1`] = `
+"package iterable_int_stream;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+interface IterableIntStream extends Iterable<Integer>, IntStream {
+  @Override
+  public void forEach(Consumer<? super Integer> action);
+
+  @Override
+  public Spliterator.OfInt spliterator();
+
+  public static IterableIntStream from(final Iterable<Integer> iterable) {
+    return from(iterable.spliterator());
+  }
+
+  public static IterableIntStream from(final Iterator<Integer> iterator) {
+    return from(() -> iterator);
+  }
+
+  public static IterableIntStream from(final Spliterator<Integer> spliterator) {
+    return from(StreamSupport.stream(spliterator, false));
+  }
+
+  public static IterableIntStream from(final Spliterator.OfInt spliterator) {
+    return from(StreamSupport.intStream(spliterator, false));
+  }
+
+  public static IterableIntStream from(final Stream<Integer> stream) {
+    return from(stream.mapToInt(i -> i));
+  }
+
+  public static IterableIntStream from(final IntStream stream) {
+    @SuppressWarnings("unchecked")
+    var proxy = (IterableIntStream) Proxy.newProxyInstance(
+      ClassLoader.getSystemClassLoader(),
+      new Class<?>[] { IterableIntStream.class },
+      (Object _proxy, Method method, Object[] args) ->
+        IntStream.class.getMethod(
+            method.getName(),
+            method.getParameterTypes()
+          ).invoke(stream, args)
+    );
+    return proxy;
+  }
+}"
+`;
+
 exports[`App can render goody: Java IterableStream 1`] = `
 "package iterable_stream;
 
@@ -204,7 +259,7 @@ final class AP {
 exports[`App can render goody: Java primes() 1`] = `
 "package primes;
 
-import iterable_stream.IterableStream;
+import iterable_int_stream.IterableIntStream;
 import simple_iterator.SimpleIterator;
 
 import java.util.ArrayList;
@@ -213,11 +268,11 @@ import java.util.List;
 final class AP {
   private AP() {}
 
-  public static IterableStream<Integer> primes() {
+  public static IterableIntStream primes() {
     final boolean[] yieldedTwo = { false };
     final List<Integer> oddPrimes = new ArrayList<>();
 
-    return IterableStream.from(
+    return IterableIntStream.from(
       SimpleIterator.toIterator(() -> {
         if (!yieldedTwo[0]) {
           yieldedTwo[0] = true;

--- a/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/tools/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -13,6 +13,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+@SuppressWarnings("overloads")
 interface IterableIntStream extends Iterable<Integer>, IntStream {
   @Override
   public Spliterator.OfInt spliterator();

--- a/tools/adventure-pack/src/scripts/package-goodies/java/splitCodeIntoClasses.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/splitCodeIntoClasses.ts
@@ -17,7 +17,7 @@ export function splitCodeIntoClasses(
   let currentClassName: string | null = null;
   for (const line of getLines(code)) {
     const classMatch = line.match(
-      /^((?:(?:abstract|final|public)\s+)*)((?:class|enum|interface|record)\s+(\S+)\s*[{<].*)$/s,
+      /^((?:(?:abstract|final|public)\s+)*)((?:class|enum|interface|record)\s+(\S+)\s*(?:extends|implements|<|{).*)$/s,
     );
     if (classMatch != null) {
       invariant(currentClassName == null, "Top-level class nesting?");

--- a/tools/adventure-pack/src/scripts/package-goodies/java/splitCodeIntoClasses.ts
+++ b/tools/adventure-pack/src/scripts/package-goodies/java/splitCodeIntoClasses.ts
@@ -15,7 +15,17 @@ export function splitCodeIntoClasses(
   const classes: Record<string, { code: string[]; declaration: string }> = {};
 
   let currentClassName: string | null = null;
+  const annotations = [];
   for (const line of getLines(code)) {
+    if (/^\@\S.*$/s.test(line)) {
+      invariant(
+        currentClassName == null,
+        "Top-level annotation inside a class?",
+      );
+      annotations.push(line);
+      continue;
+    }
+
     const classMatch = line.match(
       /^((?:(?:abstract|final|public)\s+)*)((?:class|enum|interface|record)\s+(\S+)\s*(?:extends|implements|<|{).*)$/s,
     );
@@ -28,13 +38,16 @@ export function splitCodeIntoClasses(
       currentClassName = classMatch[3];
       classes[currentClassName] = {
         code: [],
-        declaration: [
-          ...Array.from(modifiers).sort(compareStringsCaseInsensitive),
-          classMatch[2].replace(/}?\n*$/, ""),
-        ]
-          .filter(Boolean)
-          .join(" "),
+        declaration:
+          annotations.join("") +
+          [
+            ...Array.from(modifiers).sort(compareStringsCaseInsensitive),
+            classMatch[2].replace(/}?\n*$/, ""),
+          ]
+            .filter(Boolean)
+            .join(" "),
       };
+      annotations.length = 0;
 
       if (/}\n*$/.test(line)) {
         currentClassName = null;
@@ -58,6 +71,7 @@ export function splitCodeIntoClasses(
   }
 
   invariant(currentClassName == null, "Unfinished class?");
+  invariant(annotations.length === 0, "Orphaned annotations?");
 
   for (const classToIgnore of CLASSES_TO_IGNORE) {
     delete classes[classToIgnore];


### PR DESCRIPTION
Relies on `IterableIntStream`, a specialized version of `IterableStream`.
