### PR TITLE
Include a set up Python step during GitHub action project setup

### DIFF
--- a/.github/workflows/set-up-everything/action.yml
+++ b/.github/workflows/set-up-everything/action.yml
@@ -22,6 +22,11 @@ runs:
           tools/adventure-pack/goodies/java/build.gradle.kts
           tools/adventure-pack/goodies/kotlin/build.gradle.kts
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12.4
+
     - name: Install dependencies
       # I learned about https://github.com/yarnpkg/yarn/issues/2739 painfully.
       run: (cd tools && yarn install --production=false --frozen-lockfile)


### PR DESCRIPTION
Although on `ubuntu-latest` runners we already get Python, this is more explicit, and will hopefully allow us to test on other platforms shortly as well.