### PR TITLE
One `yarn format` to rule them all

### DIFF
--- a/.github/workflows/generate-health-report.js
+++ b/.github/workflows/generate-health-report.js
@@ -3,7 +3,6 @@ const { spawn } = require("node:child_process");
 const GITHUB_ACTIONS_BOT_ID = 41898282;
 
 const COMMANDS = [
-  "npx prettier --color --write .github .vscode *.js *.json && ! (git status --porcelain | grep .)",
   "yarn format && ! (git status --porcelain | grep .)",
   "yarn lint",
   "yarn typecheck",

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Ignore the workspaces directory, it will handle its own formatting.
+# See the "format" script in `package.json`.
+workspaces/

--- a/package.json
+++ b/package.json
@@ -11,10 +11,13 @@
     "workspaces/util"
   ],
   "scripts": {
-    "format": "node run-in-each-workspace.js format",
+    "format": "prettier --color --write . && node run-in-each-workspace.js format",
     "lint": "node run-in-each-workspace.js lint",
     "test": "node run-in-each-workspace.js test",
     "typecheck": "node run-in-each-workspace.js typecheck"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "devDependencies": {
+    "prettier": "3.3.3"
+  }
 }


### PR DESCRIPTION
Some of the files that are not in a workspace aren't getting formatted by Prettier, let's fix that.

Side note: The `workspaces/archive` directory still won't be getting formatted since it's not actually marked as a workspace. This will be revisited. This PR takes care of the other files that are in the repository root.
