### PR TITLE
Separate job for checking formatting on PRs

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,23 @@
+name: Check formatting on PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# TODO: maybe cancel ongoing runs for this PR so we don't generate the same annotations multiple times?
+
+jobs:
+  check-formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up everything
+        uses: ./.github/workflows/set-up-everything
+
+      - name: Check formatting
+        # TODO: Maybe turn this into a Node script, since Perl tends to be write-only...
+        run: yarn format && git status --porcelain | perl -ple 's/^.. // or die; $_ = "::error file=$_,title=Formatting error::This file does not respect the repository".chr(39)."s formatting rules.%0ARun `yarn format` in the repository root to auto-fix it."; END { die if $. }'
+        # TODO: Also write up a job summary per https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary

--- a/.github/workflows/generate-health-report.js
+++ b/.github/workflows/generate-health-report.js
@@ -3,7 +3,6 @@ const { spawn } = require("node:child_process");
 const GITHUB_ACTIONS_BOT_ID = 41898282;
 
 const COMMANDS = [
-  "yarn format && ! (git status --porcelain | grep .)",
   "yarn lint",
   "yarn typecheck",
   "yarn test",


### PR DESCRIPTION
Realistically we don't need to check it on every possible platform. Let's also try generating annotations, because that sounds fun and profitable. (See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message)

Example annotation:
<img width="566" src="https://github.com/user-attachments/assets/1505e9dc-1264-4afe-8ff7-f86fd40a0b3f">
