### PR TITLE
Run commands in all workspaces even if early failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "format": "prettier --color --write . && node run-in-each-workspace.js format",
-    "lint": "eslint --max-warnings=0 . && node run-in-each-workspace.js lint",
+    "lint": "eslint --color --max-warnings=0 . && node run-in-each-workspace.js lint",
     "test": "node run-in-each-workspace.js test",
     "typecheck": "node run-in-each-workspace.js typecheck"
   },

--- a/workspaces/adventure-pack/package.json
+++ b/workspaces/adventure-pack/package.json
@@ -46,7 +46,7 @@
     "build-app": "ts-node src/scripts/package-goodies/main.ts && tsx src/scripts/build-html.tsx && webpack && cp css/style.css dist/style.css",
     "package-goodies:test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --color --testPathIgnorePatterns=\"/goodies/\"",
     "format": "yarn goodies:java:format && yarn goodies:kotlin:format && yarn goodies:python3:format && yarn goodies:typescript:format && prettier --color --write .",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --color --max-warnings=0 .",
     "postinstall": "yarn goodies:java:install && yarn goodies:kotlin:install && yarn goodies:python3:install",
     "test": "yarn goodies:java:test && yarn goodies:kotlin:test && yarn goodies:python3:test && yarn goodies:typescript:test && yarn package-goodies:test",
     "typecheck": "tsc --project ."

--- a/workspaces/download-submissions/package.json
+++ b/workspaces/download-submissions/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "format": "prettier --color --write .",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --color --max-warnings=0 .",
     "start": "ts-node src/main.ts",
     "typecheck": "tsc --project ."
   },

--- a/workspaces/eslint-config/package.json
+++ b/workspaces/eslint-config/package.json
@@ -15,7 +15,7 @@
   "main": "eslint.config.js",
   "scripts": {
     "format": "prettier --color --write .",
-    "lint": "eslint --max-warnings=0 ."
+    "lint": "eslint --color --max-warnings=0 ."
   },
   "dependencies": {
     "@stylistic/eslint-plugin-js": "2.3.0",

--- a/workspaces/fetch-leetcode-problem-list/package.json
+++ b/workspaces/fetch-leetcode-problem-list/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "webpack && chmod +x dist/fetch-leetcode-problem-list.js",
     "format": "prettier --color --write .",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --color --max-warnings=0 .",
     "start": "ts-node src/main.ts",
     "typecheck": "tsc --project ."
   },

--- a/workspaces/get-recent-submissions/package.json
+++ b/workspaces/get-recent-submissions/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "format": "prettier --color --write .",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --color --max-warnings=0 .",
     "start": "ts-node src/main.ts",
     "typecheck": "tsc --project ."
   },

--- a/workspaces/leetcode-api/package.json
+++ b/workspaces/leetcode-api/package.json
@@ -15,7 +15,7 @@
   "main": "src/main.ts",
   "scripts": {
     "format": "prettier --color --write .",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --color --max-warnings=0 .",
     "typecheck": "tsc --project ."
   },
   "dependencies": {

--- a/workspaces/post-potd/package.json
+++ b/workspaces/post-potd/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "format": "prettier --color --write .",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --color --max-warnings=0 .",
     "start": "ts-node src/main.ts",
     "typecheck": "tsc --project ."
   },

--- a/workspaces/util/package.json
+++ b/workspaces/util/package.json
@@ -15,7 +15,7 @@
   "main": "src/index.ts",
   "scripts": {
     "format": "prettier --color --write .",
-    "lint": "eslint --max-warnings=0 .",
+    "lint": "eslint --color --max-warnings=0 .",
     "typecheck": "tsc --project ."
   },
   "dependencies": {


### PR DESCRIPTION
Previously, an early lint error in one workspace meant we might skip linting subsequent workspaces. Let's fix that -- running `yarn lint` at the top-level should find all underlying lint errors.
