### PR TITLE
Make greater use of `this.size` in `BinaryHeap` implementation

### DIFF
--- a/workspaces/adventure-pack/goodies/typescript/BinaryHeap/index.ts
+++ b/workspaces/adventure-pack/goodies/typescript/BinaryHeap/index.ts
@@ -7,7 +7,7 @@ export class BinaryHeap<T> {
 
   push(item: T): void {
     this.items.push(item);
-    this.bubbleUp(this.items.length - 1);
+    this.bubbleUp(this.size - 1);
   }
 
   peek(): T | undefined {
@@ -19,7 +19,7 @@ export class BinaryHeap<T> {
       return undefined;
     }
 
-    this.items.swap(0, this.items.length - 1);
+    this.items.swap(0, this.size - 1);
     const res = this.items.pop();
     this.bubbleDown(0);
     return res;
@@ -60,7 +60,7 @@ export class BinaryHeap<T> {
     let bestIndex = index;
     for (const childIndex of BinaryHeap.getChildIndexes(index)) {
       if (
-        childIndex < this.items.length &&
+        childIndex < this.size &&
         this.compareFn(this.items[childIndex], this.items[bestIndex]) < 0
       ) {
         bestIndex = childIndex;

--- a/workspaces/adventure-pack/src/app/BinaryHeap.ts
+++ b/workspaces/adventure-pack/src/app/BinaryHeap.ts
@@ -10,7 +10,7 @@ export class BinaryHeap<T> {
 
   push(item: T): void {
     this.items.push(item);
-    this.bubbleUp(this.items.length - 1);
+    this.bubbleUp(this.size - 1);
   }
 
   peek(): T | undefined {
@@ -22,7 +22,7 @@ export class BinaryHeap<T> {
       return undefined;
     }
 
-    swap(this.items, 0, this.items.length - 1);
+    swap(this.items, 0, this.size - 1);
     const res = this.items.pop();
     this.bubbleDown(0);
     return res;
@@ -63,7 +63,7 @@ export class BinaryHeap<T> {
     let bestIndex = index;
     for (const childIndex of BinaryHeap.getChildIndexes(index)) {
       if (
-        childIndex < this.items.length &&
+        childIndex < this.size &&
         this.compareFn(this.items[childIndex], this.items[bestIndex]) < 0
       ) {
         bestIndex = childIndex;

--- a/workspaces/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
+++ b/workspaces/adventure-pack/src/app/__tests__/__snapshots__/equip-test.ts.snap
@@ -907,7 +907,7 @@ class BinaryHeap {
 
   push(item) {
     this.items.push(item);
-    this.bubbleUp(this.items.length - 1);
+    this.bubbleUp(this.size - 1);
   }
 
   peek() {
@@ -919,7 +919,7 @@ class BinaryHeap {
       return undefined;
     }
 
-    this.items.swap(0, this.items.length - 1);
+    this.items.swap(0, this.size - 1);
     const res = this.items.pop();
     this.bubbleDown(0);
     return res;
@@ -960,7 +960,7 @@ class BinaryHeap {
     let bestIndex = index;
     for (const childIndex of BinaryHeap.getChildIndexes(index)) {
       if (
-        childIndex < this.items.length &&
+        childIndex < this.size &&
         this.compareFn(this.items[childIndex], this.items[bestIndex]) < 0
       ) {
         bestIndex = childIndex;
@@ -2226,7 +2226,7 @@ class BinaryHeap<T> {
 
   push(item: T): void {
     this.items.push(item);
-    this.bubbleUp(this.items.length - 1);
+    this.bubbleUp(this.size - 1);
   }
 
   peek(): T | undefined {
@@ -2238,7 +2238,7 @@ class BinaryHeap<T> {
       return undefined;
     }
 
-    this.items.swap(0, this.items.length - 1);
+    this.items.swap(0, this.size - 1);
     const res = this.items.pop();
     this.bubbleDown(0);
     return res;
@@ -2279,7 +2279,7 @@ class BinaryHeap<T> {
     let bestIndex = index;
     for (const childIndex of BinaryHeap.getChildIndexes(index)) {
       if (
-        childIndex < this.items.length &&
+        childIndex < this.size &&
         this.compareFn(this.items[childIndex], this.items[bestIndex]) < 0
       ) {
         bestIndex = childIndex;

--- a/workspaces/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
+++ b/workspaces/adventure-pack/src/app/__tests__/__snapshots__/render-test.ts.snap
@@ -582,7 +582,7 @@ export class BinaryHeap {
 
   push(item) {
     this.items.push(item);
-    this.bubbleUp(this.items.length - 1);
+    this.bubbleUp(this.size - 1);
   }
 
   peek() {
@@ -594,7 +594,7 @@ export class BinaryHeap {
       return undefined;
     }
 
-    this.items.swap(0, this.items.length - 1);
+    this.items.swap(0, this.size - 1);
     const res = this.items.pop();
     this.bubbleDown(0);
     return res;
@@ -635,7 +635,7 @@ export class BinaryHeap {
     let bestIndex = index;
     for (const childIndex of BinaryHeap.getChildIndexes(index)) {
       if (
-        childIndex < this.items.length &&
+        childIndex < this.size &&
         this.compareFn(this.items[childIndex], this.items[bestIndex]) < 0
       ) {
         bestIndex = childIndex;
@@ -1305,7 +1305,7 @@ export class BinaryHeap<T> {
 
   push(item: T): void {
     this.items.push(item);
-    this.bubbleUp(this.items.length - 1);
+    this.bubbleUp(this.size - 1);
   }
 
   peek(): T | undefined {
@@ -1317,7 +1317,7 @@ export class BinaryHeap<T> {
       return undefined;
     }
 
-    this.items.swap(0, this.items.length - 1);
+    this.items.swap(0, this.size - 1);
     const res = this.items.pop();
     this.bubbleDown(0);
     return res;
@@ -1358,7 +1358,7 @@ export class BinaryHeap<T> {
     let bestIndex = index;
     for (const childIndex of BinaryHeap.getChildIndexes(index)) {
       if (
-        childIndex < this.items.length &&
+        childIndex < this.size &&
         this.compareFn(this.items[childIndex], this.items[bestIndex]) < 0
       ) {
         bestIndex = childIndex;


### PR DESCRIPTION
It would have been simpler to modify the heap in https://leetcode.com/problems/sort-an-array/submissions/1332403246/ with this change.
