### PR TITLE
Turn `run-in-each-workspace` script into its own workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,18 +12,19 @@
     "workspaces/get-recent-submissions",
     "workspaces/leetcode-api",
     "workspaces/post-potd",
+    "workspaces/run-in-each-workspace",
     "workspaces/util"
   ],
   "scripts": {
-    "format": "prettier --color --write . && node run-in-each-workspace.js format",
-    "lint": "eslint --color --max-warnings=0 . && node run-in-each-workspace.js lint",
-    "test": "node run-in-each-workspace.js test",
-    "typecheck": "node run-in-each-workspace.js typecheck"
+    "format": "prettier --color --write . && yarn --silent workspace @code-chronicles/run-in-each-workspace start format",
+    "lint": "eslint --color --max-warnings=0 . && yarn --silent workspace @code-chronicles/run-in-each-workspace start lint",
+    "test": "yarn --silent workspace @code-chronicles/run-in-each-workspace start test",
+    "typecheck": "yarn --silent workspace @code-chronicles/run-in-each-workspace start typecheck"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "devDependencies": {
     "@code-chronicles/eslint-config": "0.0.1",
     "eslint": "9.7.0",
     "prettier": "3.3.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/workspaces/run-in-each-workspace/eslint.config.js
+++ b/workspaces/run-in-each-workspace/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require("@code-chronicles/eslint-config");

--- a/workspaces/run-in-each-workspace/package.json
+++ b/workspaces/run-in-each-workspace/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@code-chronicles/run-in-each-workspace",
+  "version": "0.0.1",
+  "license": "MIT",
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/code-chronicles-code/leetcode-curriculum.git",
+    "directory": "workspaces/run-in-each-workspace"
+  },
+  "author": {
+    "name": "Miorel-Lucian Palii",
+    "url": "https://github.com/miorel"
+  },
+  "scripts": {
+    "format": "prettier --color --write .",
+    "lint": "eslint --color --max-warnings=0 .",
+    "start": "ts-node src/main.ts",
+    "typecheck": "tsc --pretty --project ."
+  },
+  "dependencies": {
+    "@code-chronicles/util": "0.0.1",
+    "ts-node": "10.9.2"
+  },
+  "devDependencies": {
+    "@code-chronicles/eslint-config": "0.0.1",
+    "@types/node": "20.14.12",
+    "eslint": "9.7.0",
+    "prettier": "3.3.3",
+    "ts-node": "10.9.2",
+    "type-fest": "4.23.0",
+    "typescript": "5.5.4"
+  }
+}

--- a/workspaces/run-in-each-workspace/src/main.ts
+++ b/workspaces/run-in-each-workspace/src/main.ts
@@ -15,7 +15,7 @@ function isCommand(value: string): value is Command {
   return COMMANDS.has(value as Command);
 }
 
-const SKIP: Record<string, ReadonlySet<Command>> = {
+const SKIP: Readonly<Record<string, ReadonlySet<Command>>> = {
   "download-submissions": new Set(["test"]),
   "eslint-config": new Set(["test", "typecheck"]),
   "fetch-leetcode-problem-list": new Set(["test"]),
@@ -24,7 +24,7 @@ const SKIP: Record<string, ReadonlySet<Command>> = {
   "post-potd": new Set(["test"]),
   "run-in-each-workspace": new Set(["test"]),
   util: new Set(["test"]),
-} as const;
+};
 
 async function main() {
   if (process.argv.length < 3) {

--- a/workspaces/run-in-each-workspace/src/main.ts
+++ b/workspaces/run-in-each-workspace/src/main.ts
@@ -1,40 +1,30 @@
-const { spawn } = require("node:child_process");
-const fsPromises = require("node:fs/promises");
-const process = require("node:process");
+import process from "node:process";
+import type { IterableElement } from "type-fest";
 
-const COMMANDS = new Set(["format", "lint", "test", "typecheck"]);
+import { getCurrentGitRepositoryRoot } from "@code-chronicles/util/getCurrentGitRepositoryRoot";
+import { readWorkspaces } from "@code-chronicles/util/readWorkspaces";
+import { spawnWithSafeStdio } from "@code-chronicles/util/spawnWithSafeStdio";
+import { stripPrefixOrThrow } from "@code-chronicles/util/stripPrefixOrThrow";
 
-const SKIP = {
+// TODO: figure out a way to mark read-only
+const COMMANDS = new Set(["format", "lint", "test", "typecheck"] as const);
+
+type Command = IterableElement<typeof COMMANDS>;
+
+function isCommand(value: string): value is Command {
+  return COMMANDS.has(value as Command);
+}
+
+const SKIP: Record<string, ReadonlySet<Command>> = {
   "download-submissions": new Set(["test"]),
   "eslint-config": new Set(["test", "typecheck"]),
   "fetch-leetcode-problem-list": new Set(["test"]),
   "get-recent-submissions": new Set(["test"]),
   "leetcode-api": new Set(["test"]),
   "post-potd": new Set(["test"]),
+  "run-in-each-workspace": new Set(["test"]),
   util: new Set(["test"]),
-};
-
-// TODO: reusable utility!
-function runOrThrow(command, args, options = {}) {
-  return new Promise((resolve, reject) => {
-    const childProcess = spawn(command, args, {
-      ...options,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    childProcess.stdout.pipe(process.stdout);
-    childProcess.stderr.pipe(process.stderr);
-
-    childProcess.on("error", reject);
-    childProcess.on("exit", (exitCode) => {
-      if (exitCode) {
-        reject(new Error(`Non-zero exit code ${exitCode}.`));
-      } else {
-        resolve();
-      }
-    });
-  });
-}
+} as const;
 
 async function main() {
   if (process.argv.length < 3) {
@@ -49,19 +39,17 @@ async function main() {
   }
 
   const command = process.argv[2];
-  if (!COMMANDS.has(command)) {
+  if (!isCommand(command)) {
     throw new Error(`Invalid command: ${command}`);
   }
 
-  process.chdir(__dirname);
+  process.chdir(await getCurrentGitRepositoryRoot());
 
-  const workspaceDirectories = JSON.parse(
-    await fsPromises.readFile("package.json", "utf8"),
-  ).workspaces;
+  const workspaceDirectories = await readWorkspaces("package.json");
 
   let hasError = false;
   for (const workspaceDirectory of workspaceDirectories) {
-    const workspaceName = workspaceDirectory.replace(/^workspaces\//, "");
+    const workspaceName = stripPrefixOrThrow(workspaceDirectory, "workspaces/");
     if (SKIP[workspaceName]?.has(command)) {
       console.error(
         `Skipping command ${command} for workspace ${workspaceName}`,
@@ -71,10 +59,10 @@ async function main() {
 
     try {
       // eslint-disable-next-line no-await-in-loop
-      await runOrThrow("yarn", [command], {
+      await spawnWithSafeStdio("yarn", [command], {
         cwd: workspaceDirectory,
         shell: "bash",
-        env: { ...process.env, FORCE_COLOR: 1 },
+        env: { ...process.env, FORCE_COLOR: "1" },
       });
     } catch (err) {
       hasError = true;

--- a/workspaces/run-in-each-workspace/tsconfig.json
+++ b/workspaces/run-in-each-workspace/tsconfig.json
@@ -1,0 +1,109 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "nodenext" /* Specify what module code is generated. */,
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "nodenext" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    "resolveJsonModule": true /* Enable importing .json files. */,
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    "noEmit": true /* Disable emitting files from a compilation. */,
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    "allowUnreachableCode": false /* Disable error reporting for unreachable code. */,
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}

--- a/workspaces/util/src/readWorkspaces.ts
+++ b/workspaces/util/src/readWorkspaces.ts
@@ -1,12 +1,12 @@
 import fsPromises from "node:fs/promises";
 
-import { assertIsArray } from "@code-chronicles/util//assertIsArray";
+import { assertIsArray } from "@code-chronicles/util/assertIsArray";
 import { assertIsObject } from "@code-chronicles/util/assertIsObject";
 import { assertIsString } from "@code-chronicles/util/assertIsString";
 
 export async function readWorkspaces(path: string): Promise<string[]> {
   const packageJson = assertIsObject(
-    JSON.stringify(await fsPromises.readFile(path, "utf8")),
+    JSON.parse(await fsPromises.readFile(path, "utf8")),
   );
   const workspaces = assertIsArray(packageJson.workspaces);
   return workspaces.map(assertIsString);


### PR DESCRIPTION
This allows us to import other packages, convert it to TypeScript, etc.
