### PR TITLE
Reimplement `readWorkspaces` utility based on `yarn workspaces` output

### DIFF
--- a/.github/workflows/post-potd.yml
+++ b/.github/workflows/post-potd.yml
@@ -48,4 +48,4 @@ jobs:
           key: post-potd-script-data-${{ github.run_id }}
 
       - name: Post problem of the day
-        run: (cd workspaces/post-potd && yarn start)
+        run: yarn workspace @code-chronicles/post-potd start

--- a/.github/workflows/update-problem-data.yml
+++ b/.github/workflows/update-problem-data.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/workflows/set-up-everything
 
       - name: Get LeetCode problem list
-        run: (cd workspaces/fetch-leetcode-problem-list && yarn start) && mv -f fetch-leetcode-problem-list/problems.jsonl workspaces/archive/
+        run: yarn workspace @code-chronicles/fetch-leetcode-problem-list start && mv -f fetch-leetcode-problem-list/problems.jsonl workspaces/archive/
 
       - name: Create or update PR
         uses: peter-evans/create-pull-request@v6

--- a/workspaces/generate-health-report/src/main.ts
+++ b/workspaces/generate-health-report/src/main.ts
@@ -10,8 +10,8 @@ const COMMANDS = [
   "yarn lint",
   "yarn typecheck",
   "yarn test",
-  "(cd workspaces/adventure-pack && yarn build-app)",
-  "(cd workspaces/fetch-leetcode-problem-list && yarn build)",
+  "yarn workspace @code-chronicles/adventure-pack build-app",
+  "yarn workspace @code-chronicles/fetch-leetcode-problem-list build",
 ];
 
 export default async function ({

--- a/workspaces/util/src/getCurrentGitRepositoryRoot.ts
+++ b/workspaces/util/src/getCurrentGitRepositoryRoot.ts
@@ -3,13 +3,16 @@ import invariant from "invariant";
 import { execWithArgs } from "@code-chronicles/util/execWithArgs";
 
 export async function getCurrentGitRepositoryRoot(): Promise<string> {
-  const result = await execWithArgs("git", ["rev-parse", "--show-toplevel"]);
+  const gitCommandResult = await execWithArgs("git", [
+    "rev-parse",
+    "--show-toplevel",
+  ]);
 
-  if (result.exitCode !== 0) {
-    throw new Error(result.stderr.trim() || "Non-zero exit code!");
+  if (gitCommandResult.exitCode !== 0) {
+    throw new Error(gitCommandResult.stderr.trim() || "Non-zero exit code!");
   }
 
-  const repositoryRoot = result.stdout.trim();
+  const repositoryRoot = gitCommandResult.stdout.trim();
   invariant(repositoryRoot.length > 0, "Expected non-empty repository root!");
   return repositoryRoot;
 }


### PR DESCRIPTION
There's a command for what we're trying to do so we don't have to manually parse `package.json` ourselves. 