### PR TITLE
Add a utility like `Promise.all` but with limited concurrency

### DIFF
--- a/workspaces/download-submissions/src/constants.ts
+++ b/workspaces/download-submissions/src/constants.ts
@@ -24,3 +24,8 @@ export const LANGUAGE_TO_FILE_EXTENSION = {
   swift: "swift",
   typescript: "ts",
 } as const;
+
+export const METADATA_FILE = "submissions.jsonl";
+export const HASHES_FILE = "submissions.sha512";
+
+export const CONCURRENCY_LIMIT = 10;

--- a/workspaces/download-submissions/src/getDirnameForSubmission.ts
+++ b/workspaces/download-submissions/src/getDirnameForSubmission.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import type { TransformedSubmission } from "./transformSubmission";
 
 const PROBLEMS_PER_GROUP = 100;
@@ -14,9 +16,9 @@ export function getDirnameForSubmission(
     questionFrontendId - (questionFrontendId % PROBLEMS_PER_GROUP) + 1;
   const end = start - 1 + PROBLEMS_PER_GROUP;
 
-  return [
+  return path.join(
     "submissions",
     `${padProblemNumber(start)}-${padProblemNumber(end)}`,
     `${padProblemNumber(questionFrontendId)}-${titleSlug}`,
-  ].join("/");
+  );
 }

--- a/workspaces/download-submissions/src/main.ts
+++ b/workspaces/download-submissions/src/main.ts
@@ -1,22 +1,24 @@
 import fsPromises from "node:fs/promises";
+import path from "node:path";
 import process from "node:process";
 
 import {
   fetchSubmissionList,
   SUBMISSIONS_LIST_DEFAULT_PAGE_SIZE,
 } from "@code-chronicles/leetcode-api";
+import { promiseAllLimitingConcurrency } from "@code-chronicles/util/promiseAllLimitingConcurrency";
 import { sleep } from "@code-chronicles/util/sleep";
 
+import { CONCURRENCY_LIMIT } from "./constants";
 import { getFilenameForSubmission } from "./getFilenameForSubmission";
 import { getDirnameForSubmission } from "./getDirnameForSubmission";
+import { readPriorSubmissions } from "./readPriorSubmissions";
 import { readSecrets } from "./readSecrets";
 import {
   transformSubmission,
   type TransformedSubmission,
 } from "./transformSubmission";
-
-const METADATA_FILE = "submissions.jsonl";
-const HASHES_FILE = "submissions.sha512";
+import { writeSubmissionsMetadataAndHashes } from "./writeSubmissionsMetadataAndHashes";
 
 async function main(): Promise<void> {
   // TODO: maybe create the file from a template if it doesn't exist
@@ -24,23 +26,7 @@ async function main(): Promise<void> {
 
   const submissionsMap = new Map<string, TransformedSubmission>();
 
-  const priorSubmissionsMap: Map<string, TransformedSubmission> =
-    await fsPromises.readFile(METADATA_FILE, "utf8").then(
-      (data) => {
-        const map = new Map<string, TransformedSubmission>();
-        for (const [line] of data.matchAll(/[^\n]+/g)) {
-          const submission = JSON.parse(line) as TransformedSubmission;
-          map.set(submission.id, submission);
-        }
-        return map;
-      },
-      (e) => {
-        if (e.code === "ENOENT") {
-          return new Map();
-        }
-        throw e;
-      },
-    );
+  const priorSubmissionsMap = await readPriorSubmissions();
   console.error(
     `Prior data available on ${[priorSubmissionsMap.size]} submissions so far.`,
   );
@@ -48,7 +34,7 @@ async function main(): Promise<void> {
     ...Array.from(priorSubmissionsMap.values()).map((s) => s.timestamp),
   );
 
-  const writeSubmissionsMetadataAndHashes = async () => {
+  const maybeWriteSubmissionsMetadataAndHashes = async () => {
     // Don't do anything if we didn't get data on any submissions.
     if (submissionsMap.size === 0) {
       return;
@@ -61,31 +47,7 @@ async function main(): Promise<void> {
       return;
     }
 
-    const submissions = [...submissionsMap.values()].sort(
-      (a, b) => a.timestamp - b.timestamp,
-    );
-
-    await Promise.all([
-      fsPromises.writeFile(
-        METADATA_FILE,
-        submissions
-          .map((submission) => JSON.stringify(submission) + "\n")
-          .join(""),
-      ),
-
-      fsPromises.writeFile(
-        HASHES_FILE,
-        submissions
-          .map(
-            (submission) =>
-              // Two spaces intentional, see `shasum` manual.
-              `${submission.sha512}  ${getDirnameForSubmission(
-                submission,
-              )}/${getFilenameForSubmission(submission)}\n`,
-          )
-          .join(""),
-      ),
-    ]);
+    await writeSubmissionsMetadataAndHashes(submissionsMap);
   };
 
   try {
@@ -102,13 +64,14 @@ async function main(): Promise<void> {
         });
       } catch (e) {
         // eslint-disable-next-line no-await-in-loop
-        await writeSubmissionsMetadataAndHashes();
+        await maybeWriteSubmissionsMetadataAndHashes();
         console.error("Sleeping because of an error:", e);
         // eslint-disable-next-line no-await-in-loop
         await sleep(60000);
         continue;
       }
 
+      const writes = [];
       for (const { code, submission } of data.submissions_dump.map(
         transformSubmission,
       )) {
@@ -126,17 +89,19 @@ async function main(): Promise<void> {
           priorSubmissionsMap.clear();
         }
 
-        // TODO: Maybe batch? This isn't the slow part of this script anyway.
-        console.error(`Saving submission ${submission.id} to a file.`);
+        writes.push(async () => {
+          console.error(`Saving submission ${submission.id} to a file.`);
 
-        const dir = getDirnameForSubmission(submission);
-        // eslint-disable-next-line no-await-in-loop
-        await fsPromises.mkdir(dir, { recursive: true });
+          const dir = getDirnameForSubmission(submission);
+          await fsPromises.mkdir(dir, { recursive: true });
 
-        const filename = getFilenameForSubmission(submission);
-        // eslint-disable-next-line no-await-in-loop
-        await fsPromises.writeFile(`${dir}/${filename}`, code);
+          const filename = getFilenameForSubmission(submission);
+          await fsPromises.writeFile(path.join(dir, filename), code);
+        });
       }
+
+      // eslint-disable-next-line no-await-in-loop
+      await promiseAllLimitingConcurrency(writes, CONCURRENCY_LIMIT);
 
       console.error(
         `Downloaded data on ${[submissionsMap.size]} submissions so far.`,
@@ -146,9 +111,10 @@ async function main(): Promise<void> {
         break;
       }
 
+      // TODO: make a constant
       if (Math.random() < 0.1) {
         // eslint-disable-next-line no-await-in-loop
-        await writeSubmissionsMetadataAndHashes();
+        await maybeWriteSubmissionsMetadataAndHashes();
       }
 
       console.error("Sleeping...");
@@ -156,7 +122,7 @@ async function main(): Promise<void> {
       await sleep(3000);
     }
   } finally {
-    await writeSubmissionsMetadataAndHashes();
+    await maybeWriteSubmissionsMetadataAndHashes();
   }
 }
 

--- a/workspaces/download-submissions/src/readPriorSubmissions.ts
+++ b/workspaces/download-submissions/src/readPriorSubmissions.ts
@@ -1,0 +1,26 @@
+import fsPromises from "node:fs/promises";
+
+import { getLines } from "@code-chronicles/util/getLines";
+
+import { METADATA_FILE } from "./constants";
+import type { TransformedSubmission } from "./transformSubmission";
+
+export async function readPriorSubmissions(): Promise<
+  Map<string, TransformedSubmission>
+> {
+  const data = await fsPromises.readFile(METADATA_FILE, "utf8").catch((e) => {
+    if (e.code === "ENOENT") {
+      return "";
+    }
+    throw e;
+  });
+
+  const map = new Map<string, TransformedSubmission>();
+  for (const line of getLines(data)) {
+    // TODO: maybe validate
+    const submission = JSON.parse(line) as TransformedSubmission;
+    map.set(submission.id, submission);
+  }
+
+  return map;
+}

--- a/workspaces/download-submissions/src/writeSubmissionsMetadataAndHashes.ts
+++ b/workspaces/download-submissions/src/writeSubmissionsMetadataAndHashes.ts
@@ -1,0 +1,36 @@
+import fsPromises from "node:fs/promises";
+
+import { METADATA_FILE, HASHES_FILE } from "./constants";
+import { getFilenameForSubmission } from "./getFilenameForSubmission";
+import { getDirnameForSubmission } from "./getDirnameForSubmission";
+import type { TransformedSubmission } from "./transformSubmission";
+
+export async function writeSubmissionsMetadataAndHashes(
+  submissionsMap: ReadonlyMap<string, TransformedSubmission>,
+): Promise<void> {
+  const submissions = [...submissionsMap.values()].sort(
+    (a, b) => a.timestamp - b.timestamp,
+  );
+
+  await Promise.all([
+    fsPromises.writeFile(
+      METADATA_FILE,
+      submissions
+        .map((submission) => JSON.stringify(submission) + "\n")
+        .join(""),
+    ),
+
+    fsPromises.writeFile(
+      HASHES_FILE,
+      submissions
+        .map(
+          (submission) =>
+            // Two spaces intentional, see `shasum` manual.
+            `${submission.sha512}  ${getDirnameForSubmission(
+              submission,
+            )}/${getFilenameForSubmission(submission)}\n`,
+        )
+        .join(""),
+    ),
+  ]);
+}

--- a/workspaces/util/src/chunkBySize.ts
+++ b/workspaces/util/src/chunkBySize.ts
@@ -1,0 +1,8 @@
+export function* chunkBySize<T>(
+  array: readonly T[],
+  chunkSize: number,
+): Generator<T[], void, void> {
+  for (let i = 0; i < array.length; i += chunkSize) {
+    yield array.slice(i, i + chunkSize);
+  }
+}

--- a/workspaces/util/src/promiseAllLimitingConcurrency.ts
+++ b/workspaces/util/src/promiseAllLimitingConcurrency.ts
@@ -1,0 +1,19 @@
+import { chunkBySize } from "@code-chronicles/util/chunkBySize";
+
+export async function promiseAllLimitingConcurrency<
+  T extends readonly (() => Promise<unknown>)[] | [],
+>(
+  factories: T,
+  concurrencyLimit: number,
+): Promise<{ -readonly [P in keyof T]: Awaited<ReturnType<T[P]>> }> {
+  const res = [] as unknown as unknown[] & {
+    -readonly [P in keyof T]: Awaited<ReturnType<T[P]>>;
+  };
+
+  for (const chunk of chunkBySize(factories, concurrencyLimit)) {
+    // eslint-disable-next-line no-await-in-loop -- Intentional await in loop to limit concurrency!
+    res.push(...(await Promise.all(chunk.map((factory) => factory()))));
+  }
+
+  return res;
+}


### PR DESCRIPTION
So we can be intentional about how many promises we're running simultaneously.