### PR TITLE
Add a `whileReturnsTrueAsync` utility

### DIFF
--- a/workspaces/util/src/whileReturnsTrueAsync.ts
+++ b/workspaces/util/src/whileReturnsTrueAsync.ts
@@ -1,0 +1,6 @@
+export async function whileReturnsTrueAsync(
+  action: () => Promise<boolean>,
+): Promise<void> {
+  // eslint-disable-next-line no-await-in-loop -- This function is inherently sequential.
+  while (await action()) {}
+}


### PR DESCRIPTION
This seems like a common async idiom, and it shouldn't trigger lint errors for awaiting in a loop.