### PR TITLE
ci: put health report in the workflow summary

### DIFF
--- a/.github/workflows/generate-health-report.yml
+++ b/.github/workflows/generate-health-report.yml
@@ -9,6 +9,7 @@ permissions:
   pull-requests: write
 
 # TODO: maybe cancel ongoing runs for this PR so there's not a race condition on posting the health report comment
+
 env:
   NODE_ENV: development
 

--- a/.github/workflows/generate-health-report.yml
+++ b/.github/workflows/generate-health-report.yml
@@ -1,7 +1,7 @@
 name: Generate PR Health Report
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:

--- a/.github/workflows/generate-health-report.yml
+++ b/.github/workflows/generate-health-report.yml
@@ -1,7 +1,7 @@
 name: Generate PR Health Report
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 permissions:
@@ -9,7 +9,6 @@ permissions:
   pull-requests: write
 
 # TODO: maybe cancel ongoing runs for this PR so there's not a race condition on posting the health report comment
-
 env:
   NODE_ENV: development
 

--- a/workspaces/generate-health-report/src/main.ts
+++ b/workspaces/generate-health-report/src/main.ts
@@ -74,6 +74,8 @@ export default async function ({
       body: healthReportBody,
     });
   } else {
+    console.log(context.repo)
+    console.log(context)
     await github.rest.issues.createComment({
       owner: context.repo.owner,
       repo: context.repo.repo,

--- a/workspaces/generate-health-report/src/main.ts
+++ b/workspaces/generate-health-report/src/main.ts
@@ -5,19 +5,16 @@ import nullthrows from "nullthrows";
 
 import { spawnWithSafeStdio } from "@code-chronicles/util/spawnWithSafeStdio";
 
-const GITHUB_ACTIONS_BOT_ID = 41898282;
-
 const COMMANDS = [
   "yarn lint",
-  // "yarn typecheck",
-  // "yarn test",
-  // "yarn workspace @code-chronicles/adventure-pack build-app",
-  // "yarn workspace @code-chronicles/fetch-leetcode-problem-list build",
+  "yarn typecheck",
+  "yarn test",
+  "yarn workspace @code-chronicles/adventure-pack build-app",
+  "yarn workspace @code-chronicles/fetch-leetcode-problem-list build",
 ];
 
 export default async function ({
   context,
-  github,
   os,
 }: {
   context: Context;
@@ -25,10 +22,10 @@ export default async function ({
   os: string;
 }): Promise<void> {
   const pullRequest = nullthrows(context.payload.pull_request);
-  const prNumber = pullRequest.number;
   const healthReportPrefix = `<!-- HEALTH REPORT: ${os} -->`;
 
   const lines = [];
+  let hasError = false;
   for (const command of COMMANDS) {
     // eslint-disable-next-line no-await-in-loop
     await spawnWithSafeStdio("git", ["reset", "--hard", "HEAD"]);
@@ -43,50 +40,21 @@ export default async function ({
     } catch (err) {
       console.error(err);
       lines.push(` * \`${command}\`: ❌`);
+      hasError = true;
     }
   }
-
-  const existingHealthReport = await github.rest.issues
-    .listComments({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      // eslint-disable-next-line camelcase -- This casing is required by the API.
-      issue_number: prNumber,
-    })
-    .then(({ data }) =>
-      data.find(
-        (c) =>
-          nullthrows(c?.user).id === GITHUB_ACTIONS_BOT_ID &&
-          nullthrows(c?.body).startsWith(healthReportPrefix),
-      ),
-    );
 
   const lastCheckedCommit = pullRequest.head.sha;
   const healthReportBody =
     `${healthReportPrefix}\n\n# PR Health Report (${os})\n\nLast checked commit ${lastCheckedCommit}.\n\n` +
     lines.map((line) => line + "\n").join("");
 
-  // if (existingHealthReport) {
-  //   await github.rest.issues.updateComment({
-  //     owner: context.repo.owner,
-  //     repo: context.repo.repo,
-  //     // eslint-disable-next-line camelcase -- This casing is required by the API.
-  //     comment_id: existingHealthReport.id,
-  //     body: healthReportBody,
-  //   });
-  // } else {
-  //   console.log(context.repo)
-  //   console.log(context)
-  //   await github.rest.issues.createComment({
-  //     owner: context.repo.owner,
-  //     repo: context.repo.repo,
-  //     // eslint-disable-next-line camelcase -- This casing is required by the API.
-  //     issue_number: prNumber,
-  //     body: healthReportBody,
-  //   });
-  // }
   await writeFile(
-      nullthrows(process.env.GITHUB_STEP_SUMMARY),
-      healthReportBody
-  )
+    nullthrows(process.env.GITHUB_STEP_SUMMARY),
+    healthReportBody,
+  );
+
+  if (hasError) {
+    throw new Error();
+  }
 }

--- a/workspaces/generate-health-report/src/main.ts
+++ b/workspaces/generate-health-report/src/main.ts
@@ -86,7 +86,7 @@ export default async function ({
   //   });
   // }
   await writeFile(
-      process.env.GITHUB_STEP_SUMMARY,
+      nullthrows(process.env.GITHUB_STEP_SUMMARY),
       healthReportBody
   )
 }

--- a/workspaces/generate-health-report/src/main.ts
+++ b/workspaces/generate-health-report/src/main.ts
@@ -1,5 +1,6 @@
 import type { Context } from "@actions/github/lib/context.d.ts";
 import type { Octokit } from "@octokit/rest";
+import { writeFile } from "node:fs/promises";
 import nullthrows from "nullthrows";
 
 import { spawnWithSafeStdio } from "@code-chronicles/util/spawnWithSafeStdio";
@@ -8,10 +9,10 @@ const GITHUB_ACTIONS_BOT_ID = 41898282;
 
 const COMMANDS = [
   "yarn lint",
-  "yarn typecheck",
-  "yarn test",
-  "yarn workspace @code-chronicles/adventure-pack build-app",
-  "yarn workspace @code-chronicles/fetch-leetcode-problem-list build",
+  // "yarn typecheck",
+  // "yarn test",
+  // "yarn workspace @code-chronicles/adventure-pack build-app",
+  // "yarn workspace @code-chronicles/fetch-leetcode-problem-list build",
 ];
 
 export default async function ({
@@ -65,23 +66,27 @@ export default async function ({
     `${healthReportPrefix}\n\n# PR Health Report (${os})\n\nLast checked commit ${lastCheckedCommit}.\n\n` +
     lines.map((line) => line + "\n").join("");
 
-  if (existingHealthReport) {
-    await github.rest.issues.updateComment({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      // eslint-disable-next-line camelcase -- This casing is required by the API.
-      comment_id: existingHealthReport.id,
-      body: healthReportBody,
-    });
-  } else {
-    console.log(context.repo)
-    console.log(context)
-    await github.rest.issues.createComment({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      // eslint-disable-next-line camelcase -- This casing is required by the API.
-      issue_number: prNumber,
-      body: healthReportBody,
-    });
-  }
+  // if (existingHealthReport) {
+  //   await github.rest.issues.updateComment({
+  //     owner: context.repo.owner,
+  //     repo: context.repo.repo,
+  //     // eslint-disable-next-line camelcase -- This casing is required by the API.
+  //     comment_id: existingHealthReport.id,
+  //     body: healthReportBody,
+  //   });
+  // } else {
+  //   console.log(context.repo)
+  //   console.log(context)
+  //   await github.rest.issues.createComment({
+  //     owner: context.repo.owner,
+  //     repo: context.repo.repo,
+  //     // eslint-disable-next-line camelcase -- This casing is required by the API.
+  //     issue_number: prNumber,
+  //     body: healthReportBody,
+  //   });
+  // }
+  await writeFile(
+      process.env.GITHUB_STEP_SUMMARY,
+      healthReportBody
+  )
 }

--- a/workspaces/generate-health-report/webpack.config.mjs
+++ b/workspaces/generate-health-report/webpack.config.mjs
@@ -36,6 +36,7 @@ export default {
   externalsType: "commonjs",
   externals: {
     "node:child_process": "node:child_process",
+    "node:fs/promises": "node:fs/promises",
     "node:process": "node:process",
   },
 };


### PR DESCRIPTION
Replace comments with the workflow summary.
The health reports do not work on forks due to permission issues, but the summary does work.

The summary is located in the details.

Fixes #242 