### PR TITLE
Enable some TypeScript ESLint rules, notably `consistent-type-imports`

### DIFF
--- a/workspaces/adventure-pack/src/app/components/App.tsx
+++ b/workspaces/adventure-pack/src/app/components/App.tsx
@@ -6,7 +6,7 @@ import { HighlightedCode } from "./HighlightedCode";
 import { fetchGoodies } from "../fetchGoodies";
 import { useMergedCode } from "../useMergedCode";
 import { useAppState } from "../useAppState";
-import { Goody } from "../Goody";
+import type { Goody } from "../Goody";
 import { LanguageSelector } from "./LanguageSelector";
 
 function Column({

--- a/workspaces/adventure-pack/src/app/parsers/javaGoodyParser.ts
+++ b/workspaces/adventure-pack/src/app/parsers/javaGoodyParser.ts
@@ -1,4 +1,4 @@
-import { ReadonlyDeep } from "type-fest";
+import type { ReadonlyDeep } from "type-fest";
 import { z } from "zod";
 
 import { goodyBaseParser } from "./goodyBaseParser";

--- a/workspaces/adventure-pack/src/app/parsers/javaScriptGoodyParser.ts
+++ b/workspaces/adventure-pack/src/app/parsers/javaScriptGoodyParser.ts
@@ -1,4 +1,4 @@
-import { ReadonlyDeep } from "type-fest";
+import type { ReadonlyDeep } from "type-fest";
 import { z } from "zod";
 
 import { goodyBaseParser } from "./goodyBaseParser";

--- a/workspaces/adventure-pack/src/app/parsers/kotlinGoodyParser.ts
+++ b/workspaces/adventure-pack/src/app/parsers/kotlinGoodyParser.ts
@@ -1,4 +1,4 @@
-import { ReadonlyDeep } from "type-fest";
+import type { ReadonlyDeep } from "type-fest";
 import { z } from "zod";
 
 import { goodyBaseParser } from "./goodyBaseParser";

--- a/workspaces/adventure-pack/src/app/parsers/python3GoodyParser.ts
+++ b/workspaces/adventure-pack/src/app/parsers/python3GoodyParser.ts
@@ -1,4 +1,4 @@
-import { ReadonlyDeep } from "type-fest";
+import type { ReadonlyDeep } from "type-fest";
 import { z } from "zod";
 
 import { goodyBaseParser } from "./goodyBaseParser";

--- a/workspaces/adventure-pack/src/app/parsers/typeScriptGoodyParser.ts
+++ b/workspaces/adventure-pack/src/app/parsers/typeScriptGoodyParser.ts
@@ -1,4 +1,4 @@
-import { ReadonlyDeep } from "type-fest";
+import type { ReadonlyDeep } from "type-fest";
 import { z } from "zod";
 
 import { goodyBaseParser } from "./goodyBaseParser";

--- a/workspaces/adventure-pack/src/app/useAppState.ts
+++ b/workspaces/adventure-pack/src/app/useAppState.ts
@@ -1,5 +1,9 @@
+// eslint-disable-next-line import-x/newline-after-import -- Recursive effect of disabling the "no-duplicate-imports" rule below.
 import immutableUpdate from "immutability-helper";
-import React, { useReducer } from "react";
+// eslint-disable-next-line import-x/newline-after-import -- Recursive effect of disabling the "no-duplicate-imports" rule below.
+import { useReducer } from "react";
+// eslint-disable-next-line no-duplicate-imports -- Unavoidable duplicate import, due to needing a type import.
+import type React from "react";
 
 import type { GoodiesByLanguage } from "./fetchGoodies";
 import type { Language } from "./Language";

--- a/workspaces/adventure-pack/src/scripts/package-goodies/fillOutImportedByAndSortImports.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/fillOutImportedByAndSortImports.ts
@@ -1,5 +1,5 @@
 import invariant from "invariant";
-import { ReadonlyDeep } from "type-fest";
+import type { ReadonlyDeep } from "type-fest";
 
 import { compareStringsCaseInsensitive } from "@code-chronicles/util/compareStringsCaseInsensitive";
 import { mapObjectValues } from "@code-chronicles/util/mapObjectValues";

--- a/workspaces/adventure-pack/src/scripts/package-goodies/java/readBaseGoody.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/java/readBaseGoody.ts
@@ -1,4 +1,4 @@
-import { WritableDeep } from "type-fest";
+import type { WritableDeep } from "type-fest";
 
 import type { JavaGoody } from "../../../app/parsers/javaGoodyParser";
 import { extractJavaesqueImports } from "../extractJavaesqueImports";

--- a/workspaces/adventure-pack/src/scripts/package-goodies/kotlin/readBaseGoody.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/kotlin/readBaseGoody.ts
@@ -1,4 +1,4 @@
-import { WritableDeep } from "type-fest";
+import type { WritableDeep } from "type-fest";
 
 import type { KotlinGoody } from "../../../app/parsers/kotlinGoodyParser";
 import { extractJavaesqueImports } from "../extractJavaesqueImports";

--- a/workspaces/adventure-pack/src/scripts/package-goodies/python3/readBaseGoody.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/python3/readBaseGoody.ts
@@ -1,5 +1,4 @@
-// TODO: force type imports where possible
-import { WritableDeep } from "type-fest";
+import type { WritableDeep } from "type-fest";
 
 import type { Python3Goody } from "../../../app/parsers/python3GoodyParser";
 import { readCode } from "./readCode";

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/createSourceFile.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/createSourceFile.ts
@@ -1,4 +1,7 @@
-import { Project as TSProject, SourceFile as TSSourceFile } from "ts-morph";
+import {
+  Project as TSProject,
+  type SourceFile as TSSourceFile,
+} from "ts-morph";
 
 export function createSourceFile(code: string): TSSourceFile {
   return new TSProject({ useInMemoryFileSystem: true }).createSourceFile(

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/extractImports.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/extractImports.ts
@@ -1,4 +1,4 @@
-import { SourceFile as TSSourceFile } from "ts-morph";
+import type { SourceFile as TSSourceFile } from "ts-morph";
 
 import { removeNode } from "./removeNode";
 

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/extractModuleDeclarations.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/extractModuleDeclarations.ts
@@ -1,4 +1,4 @@
-import { SourceFile as TSSourceFile, SyntaxKind } from "ts-morph";
+import { type SourceFile as TSSourceFile, SyntaxKind } from "ts-morph";
 
 import { sortTypeScriptModuleAndInterfaceDeclarations } from "../../../app/sortTypeScriptModuleAndInterfaceDeclarations";
 import { removeNode } from "./removeNode";

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/getCodeAt.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/getCodeAt.ts
@@ -1,4 +1,4 @@
-import { SourceFile as TSSourceFile } from "ts-morph";
+import type { SourceFile as TSSourceFile } from "ts-morph";
 
 export function getCodeAt(
   sourceFile: TSSourceFile,

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/getLeadingTriviaRange.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/getLeadingTriviaRange.ts
@@ -1,4 +1,4 @@
-import { Node as TSNode } from "ts-morph";
+import type { Node as TSNode } from "ts-morph";
 
 export function getLeadingTriviaRange(node: TSNode): [number, number] {
   return [node.getPos(), node.getPos() + node.getLeadingTriviaWidth()];

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/getTrailingTriviaRange.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/getTrailingTriviaRange.ts
@@ -1,4 +1,4 @@
-import { Node as TSNode } from "ts-morph";
+import type { Node as TSNode } from "ts-morph";
 
 export function getTrailingTriviaRange(node: TSNode): [number, number] {
   return [

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/getTrivia.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/getTrivia.ts
@@ -1,4 +1,4 @@
-import { SourceFile as TSSourceFile } from "ts-morph";
+import type { SourceFile as TSSourceFile } from "ts-morph";
 
 import { getCodeAt } from "./getCodeAt";
 import { getLeadingTriviaRange } from "./getLeadingTriviaRange";

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/readBaseGoody.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/readBaseGoody.ts
@@ -1,7 +1,7 @@
 import fsPromises from "node:fs/promises";
 import path from "node:path";
 
-import { WritableDeep } from "type-fest";
+import type { WritableDeep } from "type-fest";
 
 import { stripPrefixOrThrow } from "@code-chronicles/util/stripPrefixOrThrow";
 

--- a/workspaces/adventure-pack/src/scripts/package-goodies/typescript/removeNode.ts
+++ b/workspaces/adventure-pack/src/scripts/package-goodies/typescript/removeNode.ts
@@ -1,4 +1,4 @@
-import { Node as TSNode } from "ts-morph";
+import type { Node as TSNode } from "ts-morph";
 
 import { stripSuffixOrThrow } from "@code-chronicles/util/stripSuffixOrThrow";
 

--- a/workspaces/eslint-config/eslint.config.mjs
+++ b/workspaces/eslint-config/eslint.config.mjs
@@ -1,10 +1,13 @@
+import fs from "node:fs";
+import process from "node:process";
+
+import globals from "globals";
 import importPlugin from "eslint-plugin-import-x";
 import jestPlugin from "eslint-plugin-jest";
 import stylisticPluginJs from "@stylistic/eslint-plugin-js";
 import stylisticPluginTs from "@stylistic/eslint-plugin-ts";
-import typescriptEslintPlugin from "@typescript-eslint/eslint-plugin";
 import typeScriptEslintParser from "@typescript-eslint/parser";
-import globals from "globals";
+import typescriptEslintPlugin from "@typescript-eslint/eslint-plugin";
 
 // TODO: see if we can get typechecking
 
@@ -13,6 +16,17 @@ const vanilla = {
   languageOptions: {
     globals: globals.node,
     parser: typeScriptEslintParser,
+    parserOptions: {
+      get project() {
+        const project = "./tsconfig.json";
+        if (!fs.existsSync(project)) {
+          throw new Error(
+            `No file ${project} exists in directory ${process.cwd()}`,
+          );
+        }
+        return project;
+      },
+    },
   },
   plugins: {
     "import-x": importPlugin,
@@ -234,6 +248,15 @@ const typescript = {
     "@stylistic/js/quotes": "off",
     "@stylistic/ts/quotes": vanilla.rules["@stylistic/js/quotes"],
 
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      {
+        prefer: "type-imports",
+        fixStyle: "inline-type-imports",
+        disallowTypeAnnotations: true,
+      },
+    ],
+
     // In TypeScript files, TypeScript itself should take care of this.
     "no-undef": "off",
 
@@ -246,6 +269,20 @@ const typescript = {
     // TODO: configure the additional options
     "@typescript-eslint/no-use-before-define":
       vanilla.rules["no-use-before-define"],
+
+    // TODO: enable
+    "@typescript-eslint/promise-function-async": [
+      "off",
+      {
+        allowAny: false,
+        checkArrowFunctions: true,
+        checkFunctionDeclarations: true,
+        checkFunctionExpressions: true,
+        checkMethodDeclarations: true,
+      },
+    ],
+    "@typescript-eslint/require-array-sort-compare": "error",
+    "@typescript-eslint/return-await": ["error", "always"],
   },
 };
 


### PR DESCRIPTION
This rule highlights when an import is only used for its type!
