### PR TITLE
Add copy button to HighlightedCode component

### DIFF
--- a/workspaces/adventure-pack/css/style.css
+++ b/workspaces/adventure-pack/css/style.css
@@ -21,3 +21,24 @@ body,
   font-weight: 400;
   font-style: normal;
 }
+
+.highlighted-code {
+  position: relative;
+}
+
+.copy-button {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: rgba(255, 255, 255, 0.7);
+  border: none;
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.highlighted-code:hover .copy-button {
+  opacity: 1;
+}

--- a/workspaces/adventure-pack/src/app/components/CopyButton.tsx
+++ b/workspaces/adventure-pack/src/app/components/CopyButton.tsx
@@ -1,0 +1,26 @@
+import React, { useCallback, useState } from "react";
+
+type CopyButtonProps = {
+  textToCopy: string;
+};
+
+export function CopyButton({ textToCopy }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(textToCopy);
+      setCopied(true);
+      // TODO: consider edge cases such as user clicks again within 2s or component is unmounted with pending setTimeout
+      setTimeout(() => setCopied(false), 2000);
+    } catch (e) {
+      console.error("Failed to copy text", e);
+    }
+  }, [textToCopy]);
+
+  return (
+    <button className="copy-button" onClick={handleCopy}>
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}

--- a/workspaces/adventure-pack/src/app/components/HighlightedCode.tsx
+++ b/workspaces/adventure-pack/src/app/components/HighlightedCode.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { tomorrow as syntaxHighlighterStyle } from "react-syntax-highlighter/dist/esm/styles/prism";
-
+import { CopyButton } from "./CopyButton";
 import type { Language } from "../Language";
 
 // Cross-reference with https://github.com/react-syntax-highlighter/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES_PRISM.MD
@@ -22,20 +22,23 @@ const LANGUAGE_TO_HIGHLIGHTER_LANGUAGE: Record<Language, HighlighterLanguage> =
   };
 
 type Props = {
-  children: React.ComponentProps<typeof SyntaxHighlighter>["children"];
+  children: string;
 
   language: Language;
 };
 
 export function HighlightedCode({ children, language }: Props) {
   return (
-    <SyntaxHighlighter
-      customStyle={{ fontSize: "12px", margin: 0 }}
-      language={LANGUAGE_TO_HIGHLIGHTER_LANGUAGE[language]}
-      showLineNumbers
-      style={syntaxHighlighterStyle}
-    >
-      {children}
-    </SyntaxHighlighter>
+    <div className="highlighted-code">
+      <CopyButton textToCopy={children} />
+      <SyntaxHighlighter
+        customStyle={{ fontSize: "12px", margin: 0 }}
+        language={LANGUAGE_TO_HIGHLIGHTER_LANGUAGE[language]}
+        showLineNumbers
+        style={syntaxHighlighterStyle}
+      >
+        {children}
+      </SyntaxHighlighter>
+    </div>
   );
 }


### PR DESCRIPTION
Closes https://github.com/code-chronicles-code/leetcode-curriculum/issues/152

I think it matches the overall vibe of the frontend, but I'm definitely open to feedback! For instance I'd be happy to add some simple icons or account for older browsers where [navigator.clipboard](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/clipboard#browser_compatibility) isn't supported.