### PR TITLE
Fix bug in `Number.isIntegerOrIntegerObject` test

### DIFF
--- a/workspaces/adventure-pack/goodies/typescript/Number.isIntegerOrIntegerObject/index.test.ts
+++ b/workspaces/adventure-pack/goodies/typescript/Number.isIntegerOrIntegerObject/index.test.ts
@@ -27,7 +27,7 @@ describe("Number.isIntegerOrIntegerObject", () => {
     expect(Number.isIntegerOrIntegerObject(value)).toBe(true);
   });
 
-  it.each([INTEGERS])("returns true for integer object %p", (value) => {
+  it.each(INTEGERS)("returns true for integer object %p", (value) => {
     expect(Number.isIntegerOrIntegerObject(new Number(value))).toBe(true);
   });
 


### PR DESCRIPTION
It's already an array, so we don't need to wrap it in yet another array.
