### PR TITLE
Begin a script to help prep write-ups for LeetCode

### DIFF
--- a/workspaces/javascript-leetcode-month/package.json
+++ b/workspaces/javascript-leetcode-month/package.json
@@ -15,13 +15,20 @@
   "scripts": {
     "format": "prettier --color --write .",
     "lint": "eslint --color --max-warnings=0 .",
+    "prep-write-up-for-leetcode": "ts-node scripts/prep-write-up-for-leetcode.ts",
     "typecheck": "tsc --pretty --project ."
   },
   "devDependencies": {
     "@code-chronicles/eslint-config": "0.0.1",
+    "@code-chronicles/util": "workspace:*",
+    "@types/mdast": "^3",
     "@types/node": "22.5.1",
     "eslint": "9.9.1",
+    "mdast": "3.0.0",
     "prettier": "3.3.3",
-    "typescript": "5.5.4"
+    "remark": "15.0.1",
+    "ts-node": "10.9.2",
+    "typescript": "5.5.4",
+    "unist-util-visit": "5.0.0"
   }
 }

--- a/workspaces/javascript-leetcode-month/problems/2626-array-reduce-transformation/solution.md
+++ b/workspaces/javascript-leetcode-month/problems/2626-array-reduce-transformation/solution.md
@@ -13,7 +13,7 @@
 
 ### Using `Array.prototype.reduce`
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378766665/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378766665/)
 
 ```javascript []
 /**
@@ -25,7 +25,7 @@
 const reduce = (arr, fn, init) => arr.reduce(fn, init);
 ```
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378765352/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378765352/)
 
 ```typescript []
 const reduce = <TElement, TResult>(
@@ -35,7 +35,7 @@ const reduce = <TElement, TResult>(
 ): TResult => arr.reduce(fn, init);
 ```
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378767802/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378767802/)
 
 ```javascript []
 /**
@@ -47,7 +47,7 @@ const reduce = <TElement, TResult>(
 const reduce = Function.prototype.call.bind(Array.prototype.reduce);
 ```
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378777231/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378777231/)
 
 ```typescript []
 const reduce = <TElement, TResult>(
@@ -57,7 +57,7 @@ const reduce = <TElement, TResult>(
 ): TResult => [...arr].reverse().reduceRight(fn, init);
 ```
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378778477/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378778477/)
 
 ```typescript []
 declare global {
@@ -79,7 +79,7 @@ const reduce = <TElement, TResult>(
 
 ### Iterative
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378776182/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378776182/)
 
 ```typescript []
 function reduce<TElement, TResult>(
@@ -97,7 +97,7 @@ function reduce<TElement, TResult>(
 }
 ```
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378776438/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378776438/)
 
 ```typescript []
 function reduce<TElement, TResult>(
@@ -115,7 +115,7 @@ function reduce<TElement, TResult>(
 }
 ```
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378781727/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378781727/)
 
 ```typescript []
 function reduce<TElement, TResult>(
@@ -136,7 +136,7 @@ function reduce<TElement, TResult>(
 
 ### Recursive
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378782688/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378782688/)
 
 ```typescript []
 const reduce = <TElement, TResult>(
@@ -147,7 +147,7 @@ const reduce = <TElement, TResult>(
   arr.length === 0 ? init : reduce(arr, fn, fn(init, arr.shift()));
 ```
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378769940/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378769940/)
 
 ```typescript []
 const reduce = <TElement, TResult>(
@@ -161,7 +161,7 @@ const reduce = <TElement, TResult>(
     : reduce(arr, fn, fn(init, arr[index]), index + 1);
 ```
 
-[View Submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378772700/)
+[View submission on LeetCode](https://leetcode.com/problems/array-reduce-transformation/submissions/1378772700/)
 
 ```typescript []
 function reduce<TElement, TResult>(

--- a/workspaces/javascript-leetcode-month/problems/2677-chunk-array/solution.md
+++ b/workspaces/javascript-leetcode-month/problems/2677-chunk-array/solution.md
@@ -2,7 +2,7 @@
 
 [View this Write-up on LeetCode](https://leetcode.com/problems/chunk-array/solutions/5727606/content/) | [View Problem on LeetCode](https://leetcode.com/problems/chunk-array/)
 
-> [!WARNING]
+> [!WARNING]  
 > This page includes spoilers. For a spoiler-free introduction to the problem, see [the README file](README.md).
 
 ## Summary

--- a/workspaces/javascript-leetcode-month/problems/2703-return-length-of-arguments-passed/solution.md
+++ b/workspaces/javascript-leetcode-month/problems/2703-return-length-of-arguments-passed/solution.md
@@ -2,7 +2,7 @@
 
 [View this Write-up on LeetCode](https://leetcode.com/problems/return-length-of-arguments-passed/solutions/5722508/content/) | [View Problem on LeetCode](https://leetcode.com/problems/return-length-of-arguments-passed/)
 
-> [!WARNING]
+> [!WARNING]  
 > This page includes spoilers. For a spoiler-free introduction to the problem, see [the README file](README.md).
 
 ## Summary

--- a/workspaces/javascript-leetcode-month/problems/2724-sort-by/solution.md
+++ b/workspaces/javascript-leetcode-month/problems/2724-sort-by/solution.md
@@ -127,7 +127,7 @@ Let's write some!
 
 If we don't mind mutating the input, we can write a single expression, using the subtraction idiom for the custom comparator function:
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378429436/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378429436/)
 
 ```javascript []
 /**
@@ -140,7 +140,7 @@ const sortBy = (arr, fn) => arr.sort((a, b) => fn(a) - fn(b));
 
 For TypeScript, I opted to use generics and get rid of the `JSONValue` junk from LeetCode's default template. We don't have to limit ourselves to JSON, we can handle anything as long as our input array and `fn` are in sync!
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378760710/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378760710/)
 
 ```typescript []
 const sortBy = <T>(arr: T[], fn: (value: T) => number): T[] =>
@@ -149,7 +149,7 @@ const sortBy = <T>(arr: T[], fn: (value: T) => number): T[] =>
 
 Since the problem is asking us to _return_ a sorted array, by the principle of either mutating or returning but not both, I think we should favor not modifying the input, and marking it `readonly` in TypeScript. We can still use `.sort` if we first make a copy of the input, for example using [spread syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax):
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378760479/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378760479/)
 
 ```typescript []
 const sortBy = <T>(arr: readonly T[], fn: (value: T) => number): T[] =>
@@ -160,7 +160,7 @@ const sortBy = <T>(arr: readonly T[], fn: (value: T) => number): T[] =>
 
 The code will look very similar to the code using `.sort`:
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378760265/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378760265/)
 
 ```javascript []
 /**
@@ -173,7 +173,7 @@ const sortBy = (arr, fn) => arr.toSorted((a, b) => fn(a) - fn(b));
 
 Curiously, although LeetCode's JavaScript environment supports the `.toSorted` method, at the time of this writing, LeetCode's TypeScript config isn't aware that this method exists. So we have to inform TypeScript that it does, by declaring it!
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378759820/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378759820/)
 
 ```typescript []
 declare global {
@@ -202,7 +202,7 @@ For now, let's assume that it's a good idea to minimize calls to `fn` and see so
 
 The code below uses a JavaScript object (a record) to group each element with its sort key. The braces in `({ element }) => element` are a [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378759536/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378759536/)
 
 ```typescript []
 const sortBy = <T>(arr: readonly T[], fn: (value: T) => number): T[] =>
@@ -217,7 +217,7 @@ const sortBy = <T>(arr: readonly T[], fn: (value: T) => number): T[] =>
 
 Instead of records, we could have used tuples. JavaScript doesn't have an explicit tuple data type, but arrays are often used as tuples. An explicit [tuple type annotation](https://www.typescriptlang.org/docs/handbook/2/objects.html#tuple-types) helps TypeScript distinguish it from some other kind of array, and the square brackets in `([element]) => element` are once again a [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378759168/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378759168/)
 
 ```typescript []
 const sortBy = <T>(arr: readonly T[], fn: (value: T) => number): T[] =>
@@ -229,7 +229,7 @@ const sortBy = <T>(arr: readonly T[], fn: (value: T) => number): T[] =>
 
 Instead of explicit pre-computing via `.map`, we can give `fn` a caching wrapper. Memoization is incredibly common in JavaScript code, and on LeetCode we have access to a [`memoize`](https://lodash.com/docs/#memoize) helper through [Lodash](https://lodash.com/). (In the future we'll also implement our own, in problems like [2623. Memoize](https://leetcode.com/problems/memoize/).)
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378433879/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378433879/)
 
 ```javascript []
 /**
@@ -245,7 +245,7 @@ function sortBy(arr, fn) {
 
 We can also implement our own bespoke caching wrapper, using a [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map). It's important to go with a `Map` instead of a plain JavaScript object as a map, because we don't know what type of data the input array might hold. JavaScript objects are adequate maps primarily when working with string keys. For arbitrary keys, we can't assume unique stringifications.
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378432975/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378432975/)
 
 ```typescript []
 function sortBy<T>(arr: readonly T[], fn: (value: T) => number): T[] {
@@ -267,7 +267,7 @@ function sortBy<T>(arr: readonly T[], fn: (value: T) => number): T[] {
 
 Although I think the intent of the problem was to teach us about how to `.sort` with a custom comparator, we can also choose to treat it as an algorithmic problem and implement our own sort. For example, here's a (not particularly optimized) [merge sort](https://en.wikipedia.org/wiki/Merge_sort):
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378430770/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1378430770/)
 
 ```typescript []
 function sortBy<T>(arr: readonly T[], fn: (value: T) => number): T[] {
@@ -307,7 +307,7 @@ function sortBy<T>(arr: readonly T[], fn: (value: T) => number): T[] {
 
 I couldn't resist also including a fun hack as a bonus solution. Since the problem clearly wants us to `.sort` with a custom comparator function, could we somehow get default `.sort` to do the right thing? It turns out we can...
 
-[View Submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1379421195/)
+[View submission on LeetCode](https://leetcode.com/problems/sort-by/submissions/1379421195/)
 
 ```typescript []
 const sortBy = <T>(arr: T[], fn: (value: T) => number): T[] =>

--- a/workspaces/javascript-leetcode-month/problems/2727-is-object-empty/solution.md
+++ b/workspaces/javascript-leetcode-month/problems/2727-is-object-empty/solution.md
@@ -2,7 +2,7 @@
 
 [View this Write-up on LeetCode](https://leetcode.com/problems/is-object-empty/solutions/5722608/content/) | [View Problem on LeetCode](https://leetcode.com/problems/is-object-empty/)
 
-> [!WARNING]
+> \[!WARNING]\
 > This page includes spoilers. For a spoiler-free introduction to the problem, see [the README file](README.md).
 
 ## Summary
@@ -23,7 +23,7 @@ JavaScript has an [`instanceof`](https://developer.mozilla.org/en-US/docs/Web/Ja
 
 I think you can guess what the bonus question is going to be.
 
-> [!NOTE]  
+> \[!NOTE]\
 > **What's the difference between `obj instanceof Array` and `Array.isArray(obj)`?** Major props if you know this one. Answer is at the bottom of the doc!
 
 ### Objects
@@ -64,10 +64,10 @@ If we want to use the array `length` property to solve the problem, one approach
 
 If you're experienced with JavaScript you probably knew all of that already, but do you know the answer to these bonus questions?
 
-> [!NOTE]  
+> \[!NOTE]\
 > **What happens if `Object.keys` or its friends is invoked with an array argument?** Since an array is still an object, and more generally since JavaScript is often forgiving, we can assume it probably wouldn't crash, but does it do anything useful?
 
-> [!NOTE]  
+> \[!NOTE]\
 > **What about [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from), can we use it to turn an object into an array?** It was mentioned when discussing the `arguments` object in [another write-up](../2703-return-length-of-arguments-passed/solution.md), but what does it do on an arbitrary object? Try it!
 
 Answers will be at the bottom of this doc!
@@ -92,12 +92,12 @@ for (const property of obj) {
 }
 ```
 
-> [!WARNING]  
+> \[!WARNING]\
 > In JavaScript, properties can also be inherited via an object's "prototype chain", which is how JavaScript implements classes and inheritance. When iterating over an object's properties we usually only care about its _own_ properties. It's therefore common in `for...in` loops to check ownership of the property, using [`Object.hasOwn`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) for example. Some codebases avoid `for...in` altogether for this reason and instead take the cost of `Object.keys` which only includes the object's own properties. If we intend to iterate over all (or a majority of) the object's properties, the additional cost of `Object.keys` is primarily one of allocating an additional array, which may be negligible in most applications.
 
 Although we won't need it for today, I also want to mention that for looping over arrays we typically don't use `for...in`, we instead use [`for...of`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of), which loops over the values of an iterable source.
 
-> [!NOTE]  
+> \[!NOTE]\
 > **What happens if we use `for...in` on an array?** Open the JavaScript console in your browser's developer tools and try it! Answer is at the bottom of the doc.
 
 ### Type Annotations for Objects
@@ -114,7 +114,7 @@ When an object is used as a map of keys and values, there are a couple of ways t
 
 The code provided by LeetCode for this problem once again uses an overly-complicated type. We don't care what type of values are in the object, we can accept anything. So I intend to replace the value type with `unknown`. We also don't care about the key type, either, so perhaps we should use `Record<unknown, unknown>` to mean any kind of object? That won't work unfortunately, because JavaScript objects aren't true hash maps, so they don't accept arbitrary key types. Object keys in JavaScript are usually strings, so `Record<string, unknown>` would be a reasonable type annotation. If we wanted to generalize it, we could use `Record<PropertyKey, unknown>`. The `PropertyKey` type which ships with TypeScript means "anything that can be a property key".
 
-> [!NOTE]  
+> \[!NOTE]\
 > **What happens if we use `Record<unknown, unknown>`?** Try it in LeetCode! Answer is... you guessed it, at the bottom of the doc.
 
 ## Solutions
@@ -329,7 +329,7 @@ function isEmpty(
 }
 ```
 
-> [!TIP]  
+> \[!TIP]\
 > A big takeaway of this problem is that plain JavaScript objects are rather annoying when we care about the size. Although empty-ness can still be checked somewhat efficiently if we use the `for...in` implementation, there's no good way to avoid linear time complexity if we need the number of entries. We'd have to maintain our own variable for the size and keep it in sync with the object. Thankfully, if we want a map data structure, modern JavaScript gives us another option in [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).
 
 ## Answers to Bonus Questions
@@ -412,5 +412,5 @@ function isEmpty(
    type PropertyKey = string | number | symbol;
    ```
 
-> [!TIP]  
+> \[!TIP]\
 > Thanks for reading! If you enjoyed this write-up, feel free to [up-vote it on LeetCode](https://leetcode.com/problems/is-object-empty/solutions/5722608/content/)! 🙏

--- a/workspaces/javascript-leetcode-month/scripts/prep-write-up-for-leetcode.ts
+++ b/workspaces/javascript-leetcode-month/scripts/prep-write-up-for-leetcode.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+import { processWriteUpForLeetCode } from "./processWriteUpForLeetCode";
+
+async function main(): Promise<void> {
+  const [, , file] = process.argv as (string | undefined)[];
+  if (file == null) {
+    throw new Error("Please specify a file to prep!");
+  }
+
+  const originalMarkdown = await readFile(file, "utf8");
+  const updatedMarkdown = await processWriteUpForLeetCode(originalMarkdown);
+  console.log(updatedMarkdown.replace(/\n$/, ""));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/workspaces/javascript-leetcode-month/scripts/processWriteUpForLeetCode.ts
+++ b/workspaces/javascript-leetcode-month/scripts/processWriteUpForLeetCode.ts
@@ -1,0 +1,65 @@
+import type { Link } from "mdast";
+import prettier from "prettier";
+
+import { only } from "@code-chronicles/util/only";
+
+const remarkPromise = import("remark");
+const uninstUtilVisitPromise = import("unist-util-visit");
+
+export async function processWriteUpForLeetCode(
+  markdown: string,
+): Promise<string> {
+  const [{ remark }, { visit: visitSyntaxTree }] = await Promise.all([
+    remarkPromise,
+    uninstUtilVisitPromise,
+  ]);
+
+  const unformattedProcessedMarkdown = String(
+    await remark()
+      .use(() => (tree) => {
+        visitSyntaxTree(tree, "link", (node: Link) => {
+          if (node.children.length !== 1) {
+            return;
+          }
+
+          const linkedContentNode = only(node.children);
+          if (
+            linkedContentNode.type !== "text" ||
+            !/^\s*View\s+submission(?:\s+on\s+LeetCode)?\s*$/i.test(
+              linkedContentNode.value,
+            )
+          ) {
+            return;
+          }
+
+          linkedContentNode.value = "View submission";
+        });
+
+        visitSyntaxTree(tree, "link", (node: Link) => {
+          if (node.children.length !== 1) {
+            return;
+          }
+
+          const linkedContentNode = only(node.children);
+          if (
+            linkedContentNode.type !== "text" ||
+            !/^\s*View\s+this\s+write-up\s+on\s+LeetCode\s*$/i.test(
+              linkedContentNode.value,
+            )
+          ) {
+            return;
+          }
+
+          linkedContentNode.value = "View this Write-up on GitHub TODO";
+        });
+      })
+      .process(markdown),
+  );
+
+  const formattedProcesedMarkdown = await prettier.format(
+    unformattedProcessedMarkdown,
+    { parser: "markdown" },
+  );
+
+  return formattedProcesedMarkdown;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,10 +596,16 @@ __metadata:
   resolution: "@code-chronicles/javascript-leetcode-month@workspace:workspaces/javascript-leetcode-month"
   dependencies:
     "@code-chronicles/eslint-config": "npm:0.0.1"
+    "@code-chronicles/util": "workspace:*"
+    "@types/mdast": "npm:^3"
     "@types/node": "npm:22.5.1"
     eslint: "npm:9.9.1"
+    mdast: "npm:3.0.0"
     prettier: "npm:3.3.3"
+    remark: "npm:15.0.1"
+    ts-node: "npm:10.9.2"
     typescript: "npm:5.5.4"
+    unist-util-visit: "npm:5.0.0"
   languageName: unknown
   linkType: soft
 
@@ -659,7 +665,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@code-chronicles/util@npm:0.0.1, @code-chronicles/util@workspace:workspaces/util":
+"@code-chronicles/util@npm:0.0.1, @code-chronicles/util@workspace:*, @code-chronicles/util@workspace:workspaces/util":
   version: 0.0.0-use.local
   resolution: "@code-chronicles/util@workspace:workspaces/util"
   dependencies:
@@ -1554,6 +1560,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/debug@npm:^4.0.0":
+  version: 4.1.12
+  resolution: "@types/debug@npm:4.1.12"
+  dependencies:
+    "@types/ms": "npm:*"
+  checksum: 10c0/5dcd465edbb5a7f226e9a5efd1f399c6172407ef5840686b73e3608ce135eeca54ae8037dcd9f16bdb2768ac74925b820a8b9ecc588a58ca09eca6acabe33e2f
+  languageName: node
+  linkType: hard
+
 "@types/eslint@npm:^9.6.1":
   version: 9.6.1
   resolution: "@types/eslint@npm:9.6.1"
@@ -1628,6 +1643,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/mdast@npm:^3":
+  version: 3.0.15
+  resolution: "@types/mdast@npm:3.0.15"
+  dependencies:
+    "@types/unist": "npm:^2"
+  checksum: 10c0/fcbf716c03d1ed5465deca60862e9691414f9c43597c288c7d2aefbe274552e1bbd7aeee91b88a02597e88a28c139c57863d0126fcf8416a95fdc681d054ee3d
+  languageName: node
+  linkType: hard
+
+"@types/mdast@npm:^4.0.0":
+  version: 4.0.4
+  resolution: "@types/mdast@npm:4.0.4"
+  dependencies:
+    "@types/unist": "npm:*"
+  checksum: 10c0/84f403dbe582ee508fd9c7643ac781ad8597fcbfc9ccb8d4715a2c92e4545e5772cbd0dbdf18eda65789386d81b009967fdef01b24faf6640f817287f54d9c82
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:*":
+  version: 0.7.34
+  resolution: "@types/ms@npm:0.7.34"
+  checksum: 10c0/ac80bd90012116ceb2d188fde62d96830ca847823e8ca71255616bc73991aa7d9f057b8bfab79e8ee44ffefb031ddd1bcce63ea82f9e66f7c31ec02d2d823ccc
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*, @types/node@npm:22.5.1":
   version: 22.5.1
   resolution: "@types/node@npm:22.5.1"
@@ -1676,6 +1716,13 @@ __metadata:
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
   checksum: 10c0/1f4658385ae936330581bcb8aa3a066df03867d90281cdf89cc356d404bd6579be0f11902304e1f775d92df22c6dd761d4451c804b0a4fba973e06211e9bd77c
+  languageName: node
+  linkType: hard
+
+"@types/unist@npm:*, @types/unist@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "@types/unist@npm:3.0.3"
+  checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
   languageName: node
   linkType: hard
 
@@ -2365,6 +2412,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bail@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "bail@npm:2.0.2"
+  checksum: 10c0/25cbea309ef6a1f56214187004e8f34014eb015713ea01fa5b9b7e9e776ca88d0fdffd64143ac42dc91966c915a4b7b683411b56e14929fad16153fc026ffb8b
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -2543,6 +2597,13 @@ __metadata:
   version: 1.2.4
   resolution: "character-entities@npm:1.2.4"
   checksum: 10c0/ad015c3d7163563b8a0ee1f587fb0ef305ef344e9fd937f79ca51cccc233786a01d591d989d5bf7b2e66b528ac9efba47f3b1897358324e69932f6d4b25adfe1
+  languageName: node
+  linkType: hard
+
+"character-entities@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "character-entities@npm:2.0.2"
+  checksum: 10c0/b0c645a45bcc90ff24f0e0140f4875a8436b8ef13b6bcd31ec02cfb2ca502b680362aa95386f7815bdc04b6464d48cf191210b3840d7c04241a149ede591a308
   languageName: node
   linkType: hard
 
@@ -2831,6 +2892,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.0.0":
+  version: 4.3.7
+  resolution: "debug@npm:4.3.7"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
+  languageName: node
+  linkType: hard
+
+"decode-named-character-reference@npm:^1.0.0":
+  version: 1.0.2
+  resolution: "decode-named-character-reference@npm:1.0.2"
+  dependencies:
+    character-entities: "npm:^2.0.0"
+  checksum: 10c0/66a9fc5d9b5385a2b3675c69ba0d8e893393d64057f7dbbb585265bb4fc05ec513d76943b8e5aac7d8016d20eea4499322cbf4cd6d54b466976b78f3a7587a4c
+  languageName: node
+  linkType: hard
+
 "dedent@npm:^1.0.0":
   version: 1.5.3
   resolution: "dedent@npm:1.5.3"
@@ -2857,10 +2939,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dequal@npm:^2.0.0":
+  version: 2.0.3
+  resolution: "dequal@npm:2.0.3"
+  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
+  languageName: node
+  linkType: hard
+
 "detect-newline@npm:^3.0.0":
   version: 3.1.0
   resolution: "detect-newline@npm:3.1.0"
   checksum: 10c0/c38cfc8eeb9fda09febb44bcd85e467c970d4e3bf526095394e5a4f18bc26dd0cf6b22c69c1fa9969261521c593836db335c2795218f6d781a512aea2fb8209d
+  languageName: node
+  linkType: hard
+
+"devlop@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "devlop@npm:1.1.0"
+  dependencies:
+    dequal: "npm:^2.0.0"
+  checksum: 10c0/e0928ab8f94c59417a2b8389c45c55ce0a02d9ac7fd74ef62d01ba48060129e1d594501b77de01f3eeafc7cb00773819b0df74d96251cf20b31c5b3071f45c0e
   languageName: node
   linkType: hard
 
@@ -3446,6 +3544,13 @@ __metadata:
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
   checksum: 10c0/160456d2d647e6019640bd07111634d8c353038d9fa40176afb7cd49b0548bdae83b56d05e907c2cce2300b81cae35d800ef92fefb9d0208e190fa3b7d6bb579
+  languageName: node
+  linkType: hard
+
+"extend@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "extend@npm:3.0.2"
+  checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
   languageName: node
   linkType: hard
 
@@ -4140,6 +4245,13 @@ __metadata:
   version: 3.0.3
   resolution: "is-path-inside@npm:3.0.3"
   checksum: 10c0/cf7d4ac35fb96bab6a1d2c3598fe5ebb29aafb52c0aaa482b5a3ed9d8ba3edc11631e3ec2637660c44b3ce0e61a08d54946e8af30dec0b60a7c27296c68ffd05
+  languageName: node
+  linkType: hard
+
+"is-plain-obj@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "is-plain-obj@npm:4.1.0"
+  checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
   languageName: node
   linkType: hard
 
@@ -4984,6 +5096,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"longest-streak@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "longest-streak@npm:3.1.0"
+  checksum: 10c0/7c2f02d0454b52834d1bcedef79c557bd295ee71fdabb02d041ff3aa9da48a90b5df7c0409156dedbc4df9b65da18742652aaea4759d6ece01f08971af6a7eaa
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -5073,6 +5192,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-from-markdown@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-from-markdown@npm:2.0.1"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark: "npm:^4.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+  checksum: 10c0/496596bc6419200ff6258531a0ebcaee576a5c169695f5aa296a79a85f2a221bb9247d565827c709a7c2acfb56ae3c3754bf483d86206617bd299a9658c8121c
+  languageName: node
+  linkType: hard
+
+"mdast-util-phrasing@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "mdast-util-phrasing@npm:4.1.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: 10c0/bf6c31d51349aa3d74603d5e5a312f59f3f65662ed16c58017169a5fb0f84ca98578f626c5ee9e4aa3e0a81c996db8717096705521bddb4a0185f98c12c9b42f
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-markdown@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "mdast-util-to-markdown@npm:2.1.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    "@types/unist": "npm:^3.0.0"
+    longest-streak: "npm:^3.0.0"
+    mdast-util-phrasing: "npm:^4.0.0"
+    mdast-util-to-string: "npm:^4.0.0"
+    micromark-util-decode-string: "npm:^2.0.0"
+    unist-util-visit: "npm:^5.0.0"
+    zwitch: "npm:^2.0.0"
+  checksum: 10c0/8bd37a9627a438ef6418d6642661904d0cc03c5c732b8b018a8e238ef5cc82fe8aef1940b19c6f563245e58b9659f35e527209bd3fe145f3c723ba14d18fc3e6
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-string@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "mdast-util-to-string@npm:4.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+  checksum: 10c0/2d3c1af29bf3fe9c20f552ee9685af308002488f3b04b12fa66652c9718f66f41a32f8362aa2d770c3ff464c034860b41715902ada2306bb0a055146cef064d7
+  languageName: node
+  linkType: hard
+
+"mdast@npm:3.0.0":
+  version: 3.0.0
+  resolution: "mdast@npm:3.0.0"
+  checksum: 10c0/dce2d68e9772705b675e7ebb543640e9f1361ff874eed818677304a351486904f427f87deff8bbd21942e58ed0d2ee3ddcfc1d010aea0de92b4a62ff0f94f0ff
+  languageName: node
+  linkType: hard
+
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -5084,6 +5265,242 @@ __metadata:
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 10c0/254a8a4605b58f450308fc474c82ac9a094848081bf4c06778200207820e5193726dc563a0d2c16468810516a5c97d9d3ea0ca6585d23c58ccfff2403e8dbbeb
+  languageName: node
+  linkType: hard
+
+"micromark-core-commonmark@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-core-commonmark@npm:2.0.1"
+  dependencies:
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-factory-destination: "npm:^2.0.0"
+    micromark-factory-label: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-factory-title: "npm:^2.0.0"
+    micromark-factory-whitespace: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-classify-character: "npm:^2.0.0"
+    micromark-util-html-tag-name: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-subtokenize: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/a0b280b1b6132f600518e72cb29a4dd1b2175b85f5ed5b25d2c5695e42b876b045971370daacbcfc6b4ce8cf7acbf78dd3a0284528fb422b450144f4b3bebe19
+  languageName: node
+  linkType: hard
+
+"micromark-factory-destination@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-factory-destination@npm:2.0.0"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/b73492f687d41a6a379159c2f3acbf813042346bcea523d9041d0cc6124e6715f0779dbb2a0b3422719e9764c3b09f9707880aa159557e3cb4aeb03b9d274915
+  languageName: node
+  linkType: hard
+
+"micromark-factory-label@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-factory-label@npm:2.0.0"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/8ffad00487a7891941b1d1f51d53a33c7a659dcf48617edb7a4008dad7aff67ec316baa16d55ca98ae3d75ce1d81628dbf72fedc7c6f108f740dec0d5d21c8ee
+  languageName: node
+  linkType: hard
+
+"micromark-factory-space@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-factory-space@npm:2.0.0"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/103ca954dade963d4ff1d2f27d397833fe855ddc72590205022832ef68b775acdea67949000cee221708e376530b1de78c745267b0bf8366740840783eb37122
+  languageName: node
+  linkType: hard
+
+"micromark-factory-title@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-factory-title@npm:2.0.0"
+  dependencies:
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/2b2188e7a011b1b001faf8c860286d246d5c3485ef8819270c60a5808f4c7613e49d4e481dbdff62600ef7acdba0f5100be2d125cbd2a15e236c26b3668a8ebd
+  languageName: node
+  linkType: hard
+
+"micromark-factory-whitespace@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-factory-whitespace@npm:2.0.0"
+  dependencies:
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/4e91baab0cc71873095134bd0e225d01d9786cde352701402d71b72d317973954754e8f9f1849901f165530e6421202209f4d97c460a27bb0808ec5a3fc3148c
+  languageName: node
+  linkType: hard
+
+"micromark-util-character@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "micromark-util-character@npm:2.1.0"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/fc37a76aaa5a5138191ba2bef1ac50c36b3bcb476522e98b1a42304ab4ec76f5b036a746ddf795d3de3e7004b2c09f21dd1bad42d161f39b8cfc0acd067e6373
+  languageName: node
+  linkType: hard
+
+"micromark-util-chunked@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-chunked@npm:2.0.0"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/043b5f2abc8c13a1e2e4c378ead191d1a47ed9e0cd6d0fa5a0a430b2df9e17ada9d5de5a20688a000bbc5932507e746144acec60a9589d9a79fa60918e029203
+  languageName: node
+  linkType: hard
+
+"micromark-util-classify-character@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-classify-character@npm:2.0.0"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/2bf5fa5050faa9b69f6c7e51dbaaf02329ab70fabad8229984381b356afbbf69db90f4617bec36d814a7d285fb7cad8e3c4e38d1daf4387dc9e240aa7f9a292a
+  languageName: node
+  linkType: hard
+
+"micromark-util-combine-extensions@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-combine-extensions@npm:2.0.0"
+  dependencies:
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/cd4c8d1a85255527facb419ff3b3cc3d7b7f27005c5ef5fa7ef2c4d0e57a9129534fc292a188ec2d467c2c458642d369c5f894bc8a9e142aed6696cc7989d3ea
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-numeric-character-reference@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-decode-numeric-character-reference@npm:2.0.1"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/3f6d684ee8f317c67806e19b3e761956256cb936a2e0533aad6d49ac5604c6536b2041769c6febdd387ab7175b7b7e551851bf2c1f78da943e7a3671ca7635ac
+  languageName: node
+  linkType: hard
+
+"micromark-util-decode-string@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-decode-string@npm:2.0.0"
+  dependencies:
+    decode-named-character-reference: "npm:^1.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/f5413bebb21bdb686cfa1bcfa7e9c93093a523d1b42443ead303b062d2d680a94e5e8424549f57b8ba9d786a758e5a26a97f56068991bbdbca5d1885b3aa7227
+  languageName: node
+  linkType: hard
+
+"micromark-util-encode@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-encode@npm:2.0.0"
+  checksum: 10c0/ebdaafff23100bbf4c74e63b4b1612a9ddf94cd7211d6a076bc6fb0bc32c1b48d6fb615aa0953e607c62c97d849f97f1042260d3eb135259d63d372f401bbbb2
+  languageName: node
+  linkType: hard
+
+"micromark-util-html-tag-name@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-html-tag-name@npm:2.0.0"
+  checksum: 10c0/988aa26367449bd345b627ae32cf605076daabe2dc1db71b578a8a511a47123e14af466bcd6dcbdacec60142f07bc2723ec5f7a0eed0f5319ce83b5e04825429
+  languageName: node
+  linkType: hard
+
+"micromark-util-normalize-identifier@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-normalize-identifier@npm:2.0.0"
+  dependencies:
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/93bf8789b8449538f22cf82ac9b196363a5f3b2f26efd98aef87c4c1b1f8c05be3ef6391ff38316ff9b03c1a6fd077342567598019ddd12b9bd923dacc556333
+  languageName: node
+  linkType: hard
+
+"micromark-util-resolve-all@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-resolve-all@npm:2.0.0"
+  dependencies:
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/3b912e88453dcefe728a9080c8934a75ac4732056d6576ceecbcaf97f42c5d6fa2df66db8abdc8427eb167c5ffddefe26713728cfe500bc0e314ed260d6e2746
+  languageName: node
+  linkType: hard
+
+"micromark-util-sanitize-uri@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-sanitize-uri@npm:2.0.0"
+  dependencies:
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-encode: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+  checksum: 10c0/74763ca1c927dd520d3ab8fd9856a19740acf76fc091f0a1f5d4e99c8cd5f1b81c5a0be3efb564941a071fb6d85fd951103f2760eb6cff77b5ab3abe08341309
+  languageName: node
+  linkType: hard
+
+"micromark-util-subtokenize@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "micromark-util-subtokenize@npm:2.0.1"
+  dependencies:
+    devlop: "npm:^1.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/000cefde827db129f4ed92b8fbdeb4866c5f9c93068c0115485564b0426abcb9058080aa257df9035e12ca7fa92259d66623ea750b9eb3bcdd8325d3fb6fc237
+  languageName: node
+  linkType: hard
+
+"micromark-util-symbol@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-symbol@npm:2.0.0"
+  checksum: 10c0/4e76186c185ce4cefb9cea8584213d9ffacd77099d1da30c0beb09fa21f46f66f6de4c84c781d7e34ff763fe3a06b530e132fa9004882afab9e825238d0aa8b3
+  languageName: node
+  linkType: hard
+
+"micromark-util-types@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "micromark-util-types@npm:2.0.0"
+  checksum: 10c0/d74e913b9b61268e0d6939f4209e3abe9dada640d1ee782419b04fd153711112cfaaa3c4d5f37225c9aee1e23c3bb91a1f5223e1e33ba92d33e83956a53e61de
+  languageName: node
+  linkType: hard
+
+"micromark@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "micromark@npm:4.0.0"
+  dependencies:
+    "@types/debug": "npm:^4.0.0"
+    debug: "npm:^4.0.0"
+    decode-named-character-reference: "npm:^1.0.0"
+    devlop: "npm:^1.0.0"
+    micromark-core-commonmark: "npm:^2.0.0"
+    micromark-factory-space: "npm:^2.0.0"
+    micromark-util-character: "npm:^2.0.0"
+    micromark-util-chunked: "npm:^2.0.0"
+    micromark-util-combine-extensions: "npm:^2.0.0"
+    micromark-util-decode-numeric-character-reference: "npm:^2.0.0"
+    micromark-util-encode: "npm:^2.0.0"
+    micromark-util-normalize-identifier: "npm:^2.0.0"
+    micromark-util-resolve-all: "npm:^2.0.0"
+    micromark-util-sanitize-uri: "npm:^2.0.0"
+    micromark-util-subtokenize: "npm:^2.0.0"
+    micromark-util-symbol: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+  checksum: 10c0/7e91c8d19ff27bc52964100853f1b3b32bb5b2ece57470a34ba1b2f09f4e2a183d90106c4ae585c9f2046969ee088576fed79b2f7061cba60d16652ccc2c64fd
   languageName: node
   linkType: hard
 
@@ -5270,7 +5687,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.1.1":
+"ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10c0/d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
@@ -5822,6 +6239,41 @@ __metadata:
   version: 0.14.1
   resolution: "regenerator-runtime@npm:0.14.1"
   checksum: 10c0/1b16eb2c4bceb1665c89de70dcb64126a22bc8eb958feef3cd68fe11ac6d2a4899b5cd1b80b0774c7c03591dc57d16631a7f69d2daa2ec98100e2f29f7ec4cc4
+  languageName: node
+  linkType: hard
+
+"remark-parse@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "remark-parse@npm:11.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-from-markdown: "npm:^2.0.0"
+    micromark-util-types: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/6eed15ddb8680eca93e04fcb2d1b8db65a743dcc0023f5007265dda558b09db595a087f622062ccad2630953cd5cddc1055ce491d25a81f3317c858348a8dd38
+  languageName: node
+  linkType: hard
+
+"remark-stringify@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "remark-stringify@npm:11.0.0"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    mdast-util-to-markdown: "npm:^2.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/0cdb37ce1217578f6f847c7ec9f50cbab35df5b9e3903d543e74b405404e67c07defcb23cd260a567b41b769400f6de03c2c3d9cd6ae7a6707d5c8d89ead489f
+  languageName: node
+  linkType: hard
+
+"remark@npm:15.0.1":
+  version: 15.0.1
+  resolution: "remark@npm:15.0.1"
+  dependencies:
+    "@types/mdast": "npm:^4.0.0"
+    remark-parse: "npm:^11.0.0"
+    remark-stringify: "npm:^11.0.0"
+    unified: "npm:^11.0.0"
+  checksum: 10c0/ba675e4a5b114355991d2c6f5b09a632121fc8825257b0d148b3938420713f9e9b6f012120604435d5c217d42742f60195ac6f898dc1339d313a6608a84dbc49
   languageName: node
   linkType: hard
 
@@ -6417,6 +6869,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"trough@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "trough@npm:2.2.0"
+  checksum: 10c0/58b671fc970e7867a48514168894396dd94e6d9d6456aca427cc299c004fe67f35ed7172a36449086b2edde10e78a71a284ec0076809add6834fb8f857ccb9b0
+  languageName: node
+  linkType: hard
+
 "ts-api-utils@npm:^1.3.0":
   version: 1.3.0
   resolution: "ts-api-utils@npm:1.3.0"
@@ -6628,6 +7087,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unified@npm:^11.0.0":
+  version: 11.0.5
+  resolution: "unified@npm:11.0.5"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    bail: "npm:^2.0.0"
+    devlop: "npm:^1.0.0"
+    extend: "npm:^3.0.0"
+    is-plain-obj: "npm:^4.0.0"
+    trough: "npm:^2.0.0"
+    vfile: "npm:^6.0.0"
+  checksum: 10c0/53c8e685f56d11d9d458a43e0e74328a4d6386af51c8ac37a3dcabec74ce5026da21250590d4aff6733ccd7dc203116aae2b0769abc18cdf9639a54ae528dfc9
+  languageName: node
+  linkType: hard
+
 "unique-filename@npm:^3.0.0":
   version: 3.0.0
   resolution: "unique-filename@npm:3.0.0"
@@ -6643,6 +7117,45 @@ __metadata:
   dependencies:
     imurmurhash: "npm:^0.1.4"
   checksum: 10c0/cb811d9d54eb5821b81b18205750be84cb015c20a4a44280794e915f5a0a70223ce39066781a354e872df3572e8155c228f43ff0cce94c7cbf4da2cc7cbdd635
+  languageName: node
+  linkType: hard
+
+"unist-util-is@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "unist-util-is@npm:6.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/9419352181eaa1da35eca9490634a6df70d2217815bb5938a04af3a662c12c5607a2f1014197ec9c426fbef18834f6371bfdb6f033040fa8aa3e965300d70e7e
+  languageName: node
+  linkType: hard
+
+"unist-util-stringify-position@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unist-util-stringify-position@npm:4.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+  checksum: 10c0/dfe1dbe79ba31f589108cb35e523f14029b6675d741a79dea7e5f3d098785045d556d5650ec6a8338af11e9e78d2a30df12b1ee86529cded1098da3f17ee999e
+  languageName: node
+  linkType: hard
+
+"unist-util-visit-parents@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "unist-util-visit-parents@npm:6.0.1"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+  checksum: 10c0/51b1a5b0aa23c97d3e03e7288f0cdf136974df2217d0999d3de573c05001ef04cccd246f51d2ebdfb9e8b0ed2704451ad90ba85ae3f3177cf9772cef67f56206
+  languageName: node
+  linkType: hard
+
+"unist-util-visit@npm:5.0.0, unist-util-visit@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "unist-util-visit@npm:5.0.0"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-is: "npm:^6.0.0"
+    unist-util-visit-parents: "npm:^6.0.0"
+  checksum: 10c0/51434a1d80252c1540cce6271a90fd1a106dbe624997c09ed8879279667fb0b2d3a685e02e92bf66598dcbe6cdffa7a5f5fb363af8fdf90dda6c855449ae39a5
   languageName: node
   linkType: hard
 
@@ -6694,6 +7207,26 @@ __metadata:
     "@types/istanbul-lib-coverage": "npm:^2.0.1"
     convert-source-map: "npm:^2.0.0"
   checksum: 10c0/968bcf1c7c88c04df1ffb463c179558a2ec17aa49e49376120504958239d9e9dad5281aa05f2a78542b8557f2be0b0b4c325710262f3b838b40d703d5ed30c23
+  languageName: node
+  linkType: hard
+
+"vfile-message@npm:^4.0.0":
+  version: 4.0.2
+  resolution: "vfile-message@npm:4.0.2"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    unist-util-stringify-position: "npm:^4.0.0"
+  checksum: 10c0/07671d239a075f888b78f318bc1d54de02799db4e9dce322474e67c35d75ac4a5ac0aaf37b18801d91c9f8152974ea39678aa72d7198758b07f3ba04fb7d7514
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "vfile@npm:6.0.3"
+  dependencies:
+    "@types/unist": "npm:^3.0.0"
+    vfile-message: "npm:^4.0.0"
+  checksum: 10c0/e5d9eb4810623f23758cfc2205323e33552fb5972e5c2e6587babe08fe4d24859866277404fb9e2a20afb71013860d96ec806cb257536ae463c87d70022ab9ef
   languageName: node
   linkType: hard
 
@@ -6980,5 +7513,12 @@ __metadata:
   version: 3.23.8
   resolution: "zod@npm:3.23.8"
   checksum: 10c0/8f14c87d6b1b53c944c25ce7a28616896319d95bc46a9660fe441adc0ed0a81253b02b5abdaeffedbeb23bdd25a0bf1c29d2c12dd919aef6447652dd295e3e69
+  languageName: node
+  linkType: hard
+
+"zwitch@npm:^2.0.0":
+  version: 2.0.4
+  resolution: "zwitch@npm:2.0.4"
+  checksum: 10c0/3c7830cdd3378667e058ffdb4cf2bb78ac5711214e2725900873accb23f3dfe5f9e7e5a06dcdc5f29605da976fc45c26d9a13ca334d6eea2245a15e77b8fc06e
   languageName: node
   linkType: hard


### PR DESCRIPTION
Markdown renders slightly differently on GitHub and on LeetCode. To make the write-ups look nicer on LeetCode we may want to reformat some things.

Furthermore, relative links will need to be different between GitHub and LeetCode.

So far I've been making changes like this manually by hand, but it would be nice to have some help from a script. This is the start of that script!
