### PR TITLE
Allow importing `.ts` extension

### DIFF
--- a/tsconfig-base.json
+++ b/tsconfig-base.json
@@ -35,7 +35,7 @@
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    "allowImportingTsExtensions": true /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */,
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
@@ -89,7 +89,7 @@
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    "useUnknownInCatchVariables": true /* Default catch clause variables as 'unknown' instead of 'any'. */,
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
     // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
     // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */

--- a/workspaces/adventure-pack/webpack.config.ts
+++ b/workspaces/adventure-pack/webpack.config.ts
@@ -24,9 +24,8 @@ const config: Configuration = {
           {
             loader: "ts-loader",
             options: {
-              compilerOptions: {
-                noEmit: false,
-              },
+              // TODO: Consider using fork-ts-checker-webpack-plugin for typechecking.
+              transpileOnly: true,
             },
           },
         ],
@@ -37,9 +36,6 @@ const config: Configuration = {
 
   resolve: {
     extensions: [".tsx", ".ts", "..."],
-    extensionAlias: {
-      ".js": [".ts", ".tsx", ".js"],
-    },
   },
 
   plugins: [

--- a/workspaces/chrome-extension-hello-world/webpack.config.ts
+++ b/workspaces/chrome-extension-hello-world/webpack.config.ts
@@ -20,22 +20,14 @@ const config: Configuration = {
           {
             loader: "ts-loader",
             options: {
-              compilerOptions: {
-                noEmit: false,
-              },
+              // TODO: Consider using fork-ts-checker-webpack-plugin for typechecking.
+              transpileOnly: true,
             },
           },
         ],
         exclude: /\bnode_modules\b/,
       },
     ],
-  },
-
-  resolve: {
-    extensions: [".tsx", ".ts", "..."],
-    extensionAlias: {
-      ".js": [".ts", ".tsx", ".js"],
-    },
   },
 
   optimization: {

--- a/workspaces/download-leetcode-submissions/src/getDirnameForSubmission.ts
+++ b/workspaces/download-leetcode-submissions/src/getDirnameForSubmission.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import type { TransformedSubmission } from "./transformSubmission.js";
+import type { TransformedSubmission } from "./transformSubmission.ts";
 
 const PROBLEMS_PER_GROUP = 100;
 

--- a/workspaces/download-leetcode-submissions/src/getFilenameForSubmission.ts
+++ b/workspaces/download-leetcode-submissions/src/getFilenameForSubmission.ts
@@ -3,8 +3,8 @@ import nullthrows from "nullthrows";
 import { SUBMISSION_STATUS_TO_ABBREVIATION } from "@code-chronicles/leetcode-api";
 import { timestampInSecondsToYearMonthDay } from "@code-chronicles/util/timestampInSecondsToYearMonthDay";
 
-import { LANGUAGE_TO_FILE_EXTENSION } from "./constants.js";
-import type { TransformedSubmission } from "./transformSubmission.js";
+import { LANGUAGE_TO_FILE_EXTENSION } from "./constants.ts";
+import type { TransformedSubmission } from "./transformSubmission.ts";
 
 export function getFilenameForSubmission({
   id,

--- a/workspaces/download-leetcode-submissions/src/main.ts
+++ b/workspaces/download-leetcode-submissions/src/main.ts
@@ -10,16 +10,16 @@ import { promiseAllLimitingConcurrency } from "@code-chronicles/util/promiseAllL
 import { sleep } from "@code-chronicles/util/sleep";
 import { whileReturnsTrueAsync } from "@code-chronicles/util/whileReturnsTrueAsync";
 
-import { CONCURRENCY_LIMIT } from "./constants.js";
-import { getDirnameForSubmission } from "./getDirnameForSubmission.js";
-import { getFilenameForSubmission } from "./getFilenameForSubmission.js";
-import { readPriorSubmissions } from "./readPriorSubmissions.js";
-import { readSecrets } from "./readSecrets.js";
+import { CONCURRENCY_LIMIT } from "./constants.ts";
+import { getDirnameForSubmission } from "./getDirnameForSubmission.ts";
+import { getFilenameForSubmission } from "./getFilenameForSubmission.ts";
+import { readPriorSubmissions } from "./readPriorSubmissions.ts";
+import { readSecrets } from "./readSecrets.ts";
 import {
   transformSubmission,
   type TransformedSubmission,
-} from "./transformSubmission.js";
-import { writeSubmissionsMetadataAndHashes } from "./writeSubmissionsMetadataAndHashes.js";
+} from "./transformSubmission.ts";
+import { writeSubmissionsMetadataAndHashes } from "./writeSubmissionsMetadataAndHashes.ts";
 
 async function main(): Promise<void> {
   // TODO: maybe create the file from a template if it doesn't exist

--- a/workspaces/download-leetcode-submissions/src/readPriorSubmissions.ts
+++ b/workspaces/download-leetcode-submissions/src/readPriorSubmissions.ts
@@ -2,8 +2,8 @@ import fsPromises from "node:fs/promises";
 
 import { getLines } from "@code-chronicles/util/getLines";
 
-import { METADATA_FILE } from "./constants.js";
-import type { TransformedSubmission } from "./transformSubmission.js";
+import { METADATA_FILE } from "./constants.ts";
+import type { TransformedSubmission } from "./transformSubmission.ts";
 
 export async function readPriorSubmissions(): Promise<
   Map<string, TransformedSubmission>

--- a/workspaces/download-leetcode-submissions/src/writeSubmissionsMetadataAndHashes.ts
+++ b/workspaces/download-leetcode-submissions/src/writeSubmissionsMetadataAndHashes.ts
@@ -1,9 +1,9 @@
 import { writeFile } from "node:fs/promises";
 
-import { METADATA_FILE, HASHES_FILE } from "./constants.js";
-import { getDirnameForSubmission } from "./getDirnameForSubmission.js";
-import { getFilenameForSubmission } from "./getFilenameForSubmission.js";
-import type { TransformedSubmission } from "./transformSubmission.js";
+import { METADATA_FILE, HASHES_FILE } from "./constants.ts";
+import { getDirnameForSubmission } from "./getDirnameForSubmission.ts";
+import { getFilenameForSubmission } from "./getFilenameForSubmission.ts";
+import type { TransformedSubmission } from "./transformSubmission.ts";
 
 export async function writeSubmissionsMetadataAndHashes(
   submissionsMap: ReadonlyMap<string, TransformedSubmission>,

--- a/workspaces/download-leetcode-submissions/webpack.config.ts
+++ b/workspaces/download-leetcode-submissions/webpack.config.ts
@@ -28,22 +28,14 @@ const config: Configuration = {
           {
             loader: "ts-loader",
             options: {
-              compilerOptions: {
-                noEmit: false,
-              },
+              // TODO: Consider using fork-ts-checker-webpack-plugin for typechecking.
+              transpileOnly: true,
             },
           },
         ],
         exclude: /\bnode_modules\b/,
       },
     ],
-  },
-
-  resolve: {
-    extensions: [".tsx", ".ts", "..."],
-    extensionAlias: {
-      ".js": [".ts", ".tsx", ".js"],
-    },
   },
 
   externalsType: "commonjs",

--- a/workspaces/fetch-leetcode-problem-list/webpack.config.ts
+++ b/workspaces/fetch-leetcode-problem-list/webpack.config.ts
@@ -28,22 +28,14 @@ const config: Configuration = {
           {
             loader: "ts-loader",
             options: {
-              compilerOptions: {
-                noEmit: false,
-              },
+              // TODO: Consider using fork-ts-checker-webpack-plugin for typechecking.
+              transpileOnly: true,
             },
           },
         ],
         exclude: /\bnode_modules\b/,
       },
     ],
-  },
-
-  resolve: {
-    extensions: [".tsx", ".ts", "..."],
-    extensionAlias: {
-      ".js": [".ts", ".tsx", ".js"],
-    },
   },
 
   externalsType: "commonjs",

--- a/workspaces/fetch-recent-accepted-leetcode-submissions/webpack.config.ts
+++ b/workspaces/fetch-recent-accepted-leetcode-submissions/webpack.config.ts
@@ -28,22 +28,14 @@ const config: Configuration = {
           {
             loader: "ts-loader",
             options: {
-              compilerOptions: {
-                noEmit: false,
-              },
+              // TODO: Consider using fork-ts-checker-webpack-plugin for typechecking.
+              transpileOnly: true,
             },
           },
         ],
         exclude: /\bnode_modules\b/,
       },
     ],
-  },
-
-  resolve: {
-    extensions: [".tsx", ".ts", "..."],
-    extensionAlias: {
-      ".js": [".ts", ".tsx", ".js"],
-    },
   },
 
   externalsType: "commonjs",

--- a/workspaces/javascript-leetcode-month/scripts/prep-write-up-for-leetcode.ts
+++ b/workspaces/javascript-leetcode-month/scripts/prep-write-up-for-leetcode.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import process from "node:process";
 
-import { processWriteUpForLeetCode } from "./processWriteUpForLeetCode.js";
+import { processWriteUpForLeetCode } from "./processWriteUpForLeetCode.ts";
 
 async function main(): Promise<void> {
   const [, , file] = process.argv as (string | undefined)[];

--- a/workspaces/leetcode-api/src/fetchActiveDailyCodingChallengeQuestion.ts
+++ b/workspaces/leetcode-api/src/fetchActiveDailyCodingChallengeQuestion.ts
@@ -6,9 +6,9 @@ import { squashWhitespace } from "@code-chronicles/util/squashWhitespace";
 import { MS_IN_SEC } from "@code-chronicles/util/timeConstants";
 import { timestampInSecondsToYearMonthDay } from "@code-chronicles/util/timestampInSecondsToYearMonthDay";
 
-import { fetchGraphQLData } from "./fetchGraphQLData.js";
-import { questionDifficultyZodType } from "./zod-types/questionDifficultyZodType.js";
-import { questionTitleSlugZodType } from "./zod-types/questionTitleSlugZodType.js";
+import { fetchGraphQLData } from "./fetchGraphQLData.ts";
+import { questionDifficultyZodType } from "./zod-types/questionDifficultyZodType.ts";
+import { questionTitleSlugZodType } from "./zod-types/questionTitleSlugZodType.ts";
 
 const QUERY = squashWhitespace(`
   query {

--- a/workspaces/leetcode-api/src/fetchGraphQLTypeInformation.ts
+++ b/workspaces/leetcode-api/src/fetchGraphQLTypeInformation.ts
@@ -9,9 +9,9 @@ import {
 import { squashWhitespace } from "@code-chronicles/util/squashWhitespace";
 import { stripPrefixOrThrow } from "@code-chronicles/util/stripPrefixOrThrow";
 
-import { fetchGraphQLData } from "./fetchGraphQLData.js";
-import { normalizeGraphQLDescription } from "./normalizeGraphQLDescription.js";
-import { sortByName } from "./sortByName.js";
+import { fetchGraphQLData } from "./fetchGraphQLData.ts";
+import { normalizeGraphQLDescription } from "./normalizeGraphQLDescription.ts";
+import { sortByName } from "./sortByName.ts";
 
 function getTypeFields(depth: number): string {
   const base = "name kind";

--- a/workspaces/leetcode-api/src/fetchQuestionList.ts
+++ b/workspaces/leetcode-api/src/fetchQuestionList.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 import { numericIdAsNumberZodType } from "@code-chronicles/util/numericIdAsNumberZodType";
 import { squashWhitespace } from "@code-chronicles/util/squashWhitespace";
 
-import { fetchGraphQLData } from "./fetchGraphQLData.js";
-import { questionDifficultyZodType } from "./zod-types/questionDifficultyZodType.js";
-import { questionTitleSlugZodType } from "./zod-types/questionTitleSlugZodType.js";
+import { fetchGraphQLData } from "./fetchGraphQLData.ts";
+import { questionDifficultyZodType } from "./zod-types/questionDifficultyZodType.ts";
+import { questionTitleSlugZodType } from "./zod-types/questionTitleSlugZodType.ts";
 
 const QUERY = squashWhitespace(`
   query ($categorySlug: String!, $limit: Int, $skip: Int, $filters: QuestionListFilterInput!) {

--- a/workspaces/leetcode-api/src/fetchRecentAcSubmissionList.ts
+++ b/workspaces/leetcode-api/src/fetchRecentAcSubmissionList.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import { numericIdAsStringZodType } from "@code-chronicles/util/numericIdAsStringZodType";
 import { squashWhitespace } from "@code-chronicles/util/squashWhitespace";
 
-import { fetchGraphQLData } from "./fetchGraphQLData.js";
-import { questionTitleSlugZodType } from "./zod-types/questionTitleSlugZodType.js";
+import { fetchGraphQLData } from "./fetchGraphQLData.ts";
+import { questionTitleSlugZodType } from "./zod-types/questionTitleSlugZodType.ts";
 
 const QUERY = squashWhitespace(`
   query ($username: String!, $limit: Int!) {

--- a/workspaces/leetcode-api/src/fetchSubmissionList.ts
+++ b/workspaces/leetcode-api/src/fetchSubmissionList.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { numericIdAsNumberZodType } from "@code-chronicles/util/numericIdAsNumberZodType";
 import { numericIdAsStringZodType } from "@code-chronicles/util/numericIdAsStringZodType";
 
-import { questionTitleSlugZodType } from "./zod-types/questionTitleSlugZodType.js";
+import { questionTitleSlugZodType } from "./zod-types/questionTitleSlugZodType.ts";
 
 export const SUBMISSION_STATUS_TO_DISPLAY_TEXT: ReadonlyMap<number, string> =
   new Map([

--- a/workspaces/leetcode-api/src/main.ts
+++ b/workspaces/leetcode-api/src/main.ts
@@ -2,24 +2,24 @@ export {
   fetchActiveDailyCodingChallengeQuestionWithDateValidation,
   fetchActiveDailyCodingChallengeQuestionWithoutDateValidation,
   type ActiveDailyCodingChallengeQuestion,
-} from "./fetchActiveDailyCodingChallengeQuestion.js";
+} from "./fetchActiveDailyCodingChallengeQuestion.ts";
 
 export {
   fetchGraphQLTypeInformation,
   type LeetCodeGraphQLType,
-} from "./fetchGraphQLTypeInformation.js";
+} from "./fetchGraphQLTypeInformation.ts";
 
 export {
   fetchQuestionList,
   CategorySlug,
   type QuestionList,
   type QuestionListQuestion,
-} from "./fetchQuestionList.js";
+} from "./fetchQuestionList.ts";
 
 export {
   fetchRecentAcSubmissionList,
   type RecentAcSubmission,
-} from "./fetchRecentAcSubmissionList.js";
+} from "./fetchRecentAcSubmissionList.ts";
 
 export {
   PAGE_SIZE as SUBMISSIONS_LIST_DEFAULT_PAGE_SIZE,
@@ -28,6 +28,6 @@ export {
   fetchSubmissionList,
   type Submission,
   type SubmissionList,
-} from "./fetchSubmissionList.js";
+} from "./fetchSubmissionList.ts";
 
-export type { QuestionDifficulty } from "./zod-types/questionDifficultyZodType.js";
+export type { QuestionDifficulty } from "./zod-types/questionDifficultyZodType.ts";

--- a/workspaces/leetcode-api/src/scripts/scrape-graphql-schema/getFakeScalarType.ts
+++ b/workspaces/leetcode-api/src/scripts/scrape-graphql-schema/getFakeScalarType.ts
@@ -7,7 +7,7 @@ import {
 } from "graphql";
 import nullthrows from "nullthrows";
 
-import type { InnerType } from "../../fetchGraphQLTypeInformation.js";
+import type { InnerType } from "../../fetchGraphQLTypeInformation.ts";
 
 export function getFakeScalarType(
   innerType: InnerType,

--- a/workspaces/leetcode-api/src/scripts/scrape-graphql-schema/main.ts
+++ b/workspaces/leetcode-api/src/scripts/scrape-graphql-schema/main.ts
@@ -9,14 +9,14 @@ import { popMany } from "@code-chronicles/util/popMany";
 import { sleep } from "@code-chronicles/util/sleep";
 import { whileReturnsTrueAsync } from "@code-chronicles/util/whileReturnsTrueAsync";
 
-import { SCHEMA_FILE } from "./constants.js";
+import { SCHEMA_FILE } from "./constants.ts";
 import {
   fetchGraphQLTypeInformation,
   type InnerType,
   type LeetCodeGraphQLType,
-} from "../../fetchGraphQLTypeInformation.js";
-import { readSeedGraphQLTypeNames } from "./readSeedGraphQLTypeNames.js";
-import { stringifyGraphQLSchema } from "./stringifyGraphQLSchema.js";
+} from "../../fetchGraphQLTypeInformation.ts";
+import { readSeedGraphQLTypeNames } from "./readSeedGraphQLTypeNames.ts";
+import { stringifyGraphQLSchema } from "./stringifyGraphQLSchema.ts";
 
 const BATCH_SIZE = 100;
 

--- a/workspaces/leetcode-api/src/scripts/scrape-graphql-schema/readSeedGraphQLTypeNames.ts
+++ b/workspaces/leetcode-api/src/scripts/scrape-graphql-schema/readSeedGraphQLTypeNames.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 
 import { buildSchema } from "graphql";
 
-import { SCHEMA_FILE } from "./constants.js";
+import { SCHEMA_FILE } from "./constants.ts";
 
 export async function readSeedGraphQLTypeNames(): Promise<string[]> {
   // Start with some built-in types.

--- a/workspaces/leetcode-api/src/scripts/scrape-graphql-schema/stringifyGraphQLSchema.ts
+++ b/workspaces/leetcode-api/src/scripts/scrape-graphql-schema/stringifyGraphQLSchema.ts
@@ -18,10 +18,10 @@ import { getRandomBytes } from "@code-chronicles/util/getRandomBytes";
 import { invariantViolation } from "@code-chronicles/util/invariantViolation";
 import { maybeThrow } from "@code-chronicles/util/maybeThrow";
 
-import type { LeetCodeGraphQLType } from "../../fetchGraphQLTypeInformation.js";
-import { encodeValue } from "./encodeValue.js";
-import { getFakeScalarType } from "./getFakeScalarType.js";
-import { parseEncodedValues } from "./parseEncodedValues.js";
+import type { LeetCodeGraphQLType } from "../../fetchGraphQLTypeInformation.ts";
+import { encodeValue } from "./encodeValue.ts";
+import { getFakeScalarType } from "./getFakeScalarType.ts";
+import { parseEncodedValues } from "./parseEncodedValues.ts";
 
 export async function stringifyGraphQLSchema(
   types: readonly LeetCodeGraphQLType[],

--- a/workspaces/leetcode-api/src/scripts/validate-graphql-schema/main.ts
+++ b/workspaces/leetcode-api/src/scripts/validate-graphql-schema/main.ts
@@ -4,7 +4,7 @@ import { buildSchema, validateSchema } from "graphql";
 
 import { maybeThrow } from "@code-chronicles/util/maybeThrow";
 
-import { SCHEMA_FILE } from "../scrape-graphql-schema/constants.js";
+import { SCHEMA_FILE } from "../scrape-graphql-schema/constants.ts";
 
 async function main(): Promise<void> {
   const schema = buildSchema(await readFile(SCHEMA_FILE, "utf8"));

--- a/workspaces/post-leetcode-potd-to-discord/src/getPotdMessage.ts
+++ b/workspaces/post-leetcode-potd-to-discord/src/getPotdMessage.ts
@@ -2,7 +2,7 @@ import type { ActiveDailyCodingChallengeQuestion } from "@code-chronicles/leetco
 import { SEC_IN_DAY } from "@code-chronicles/util/timeConstants";
 import { yearMonthDayToTimestampInSeconds } from "@code-chronicles/util/yearMonthDayToTimestampInSeconds";
 
-import { formatTimestampForDiscord } from "./formatTimestampForDiscord.js";
+import { formatTimestampForDiscord } from "./formatTimestampForDiscord.ts";
 
 export function getPotdMessage({
   date,

--- a/workspaces/post-leetcode-potd-to-discord/src/main.ts
+++ b/workspaces/post-leetcode-potd-to-discord/src/main.ts
@@ -11,11 +11,11 @@ import {
 import { whileReturnsTrueAsync } from "@code-chronicles/util/whileReturnsTrueAsync";
 import { yearMonthDayToTimestampInSeconds } from "@code-chronicles/util/yearMonthDayToTimestampInSeconds";
 
-import { getPotdMessage } from "./getPotdMessage.js";
-import { readScriptData } from "./readScriptData.js";
-import { readSecrets } from "./readSecrets.js";
-import { sendDiscordMessage } from "./sendDiscordMessage.js";
-import { writeScriptData } from "./writeScriptData.js";
+import { getPotdMessage } from "./getPotdMessage.ts";
+import { readScriptData } from "./readScriptData.ts";
+import { readSecrets } from "./readSecrets.ts";
+import { sendDiscordMessage } from "./sendDiscordMessage.ts";
+import { writeScriptData } from "./writeScriptData.ts";
 
 async function main(): Promise<void> {
   // TODO: maybe create the file from a template if it doesn't exist

--- a/workspaces/post-leetcode-potd-to-discord/src/sendDiscordMessage.ts
+++ b/workspaces/post-leetcode-potd-to-discord/src/sendDiscordMessage.ts
@@ -1,7 +1,7 @@
 import { ChannelType, Client, GatewayIntentBits } from "discord.js";
 import invariant from "invariant";
 
-import type { Secrets } from "./readSecrets.js";
+import type { Secrets } from "./readSecrets.ts";
 
 export async function sendDiscordMessage(
   { discordChannelID, discordToken }: Secrets,

--- a/workspaces/post-leetcode-potd-to-discord/src/writeScriptData.ts
+++ b/workspaces/post-leetcode-potd-to-discord/src/writeScriptData.ts
@@ -1,6 +1,6 @@
 import { writeFile } from "node:fs/promises";
 
-import { DATA_FILE, type Data } from "./readScriptData.js";
+import { DATA_FILE, type Data } from "./readScriptData.ts";
 
 export async function writeScriptData(data: Data): Promise<void> {
   await writeFile(DATA_FILE, JSON.stringify(data), {

--- a/workspaces/post-leetcode-potd-to-discord/webpack.config.ts
+++ b/workspaces/post-leetcode-potd-to-discord/webpack.config.ts
@@ -28,22 +28,14 @@ const config: Configuration = {
           {
             loader: "ts-loader",
             options: {
-              compilerOptions: {
-                noEmit: false,
-              },
+              // TODO: Consider using fork-ts-checker-webpack-plugin for typechecking.
+              transpileOnly: true,
             },
           },
         ],
         exclude: /\bnode_modules\b/,
       },
     ],
-  },
-
-  resolve: {
-    extensions: [".tsx", ".ts", "..."],
-    extensionAlias: {
-      ".js": [".ts", ".tsx", ".js"],
-    },
   },
 
   externalsType: "commonjs",

--- a/workspaces/repository-scripts/src/main.ts
+++ b/workspaces/repository-scripts/src/main.ts
@@ -1,7 +1,7 @@
 import process from "node:process";
 
-import { runCommands } from "./runCommands.js";
-import { SCRIPTS, isScript } from "./scripts.js";
+import { runCommands } from "./runCommands.ts";
+import { SCRIPTS, isScript } from "./scripts.ts";
 
 async function main() {
   if (process.argv.length < 3) {

--- a/workspaces/repository-scripts/src/runCommands.ts
+++ b/workspaces/repository-scripts/src/runCommands.ts
@@ -13,7 +13,7 @@ import {
   SCRIPTS,
   SCRIPTS_TO_SKIP_BY_WORKSPACE,
   type Script,
-} from "./scripts.js";
+} from "./scripts.ts";
 
 type FailedCommand = {
   command: string;


### PR DESCRIPTION
TypeScript has this fun behavior wherein you have to import files with a `.js` extension even though those files don't exist. Fortunately, we can enable importing with a `.ts` extension if the compiler is in `noEmit` mode.