### PR TITLE
Add stub archive workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,18 +5,7 @@
     "url": "https://github.com/code-chronicles-code/leetcode-curriculum.git"
   },
   "workspaces": [
-    "workspaces/adventure-pack",
-    "workspaces/download-leetcode-submissions",
-    "workspaces/eslint-config",
-    "workspaces/fetch-leetcode-problem-list",
-    "workspaces/fetch-recent-accepted-leetcode-submissions",
-    "workspaces/generate-health-report",
-    "workspaces/javascript-leetcode-month",
-    "workspaces/leetcode-api",
-    "workspaces/leetcode-zen-mode",
-    "workspaces/post-leetcode-potd-to-discord",
-    "workspaces/repository-scripts",
-    "workspaces/util"
+    "workspaces/*"
   ],
   "type": "module",
   "scripts": {

--- a/workspaces/archive/package.json
+++ b/workspaces/archive/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@code-chronicles/archive",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/code-chronicles-code/leetcode-curriculum.git",
+    "directory": "workspaces/archive"
+  },
+  "type": "module"
+}

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -54,11 +54,12 @@ module.exports = defineConfig({
       }
     }
 
-    // Expect each workspace to specify a version, except for the root.
+    // Expect each workspace to specify a version, except for the root and
+    // anything private.
     for (const workspace of Yarn.workspaces()) {
       if (workspace.cwd === ".") {
         workspace.unset("version");
-      } else {
+      } else if (!workspace.manifest.private) {
         workspace.set("version", workspace.manifest.version ?? "0.0.1");
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,6 +491,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@code-chronicles/archive@workspace:workspaces/archive":
+  version: 0.0.0-use.local
+  resolution: "@code-chronicles/archive@workspace:workspaces/archive"
+  languageName: unknown
+  linkType: soft
+
 "@code-chronicles/download-leetcode-submissions@workspace:workspaces/download-leetcode-submissions":
   version: 0.0.0-use.local
   resolution: "@code-chronicles/download-leetcode-submissions@workspace:workspaces/download-leetcode-submissions"


### PR DESCRIPTION
This way we can declare that anything in the `workspaces` directory is a workspace, making it simpler to add new workspaces by simply adding a new directory.
